### PR TITLE
Add keyboard shortcuts for selection and property

### DIFF
--- a/src/keyboardInteraction.ts
+++ b/src/keyboardInteraction.ts
@@ -98,6 +98,24 @@ export function handleKeyDown(tray: Tray, event: KeyboardEvent): void {
         showMarkdownOutput(tray)
         break
       }
+    case "S":
+      event.preventDefault();
+      const checkbox = tray.element.querySelector<HTMLInputElement>(
+        ".tray-checkbox",
+      );
+      if (checkbox) {
+        checkbox.checked = !checkbox.checked;
+        checkbox.dispatchEvent(new Event("change"));
+      }
+      break;
+    case "P":
+      event.preventDefault();
+      const key = prompt("Property name:", "priority") || "priority";
+      const value = prompt(`Value for '${key}':`, "");
+      if (value !== null) {
+        tray.addProperty(key, value);
+      }
+      break;
     // case " ":
     //   if (event.ctrlKey) {
     //     event.preventDefault();


### PR DESCRIPTION
## Summary
- add `Shift+S` shortcut to toggle tray selection checkbox
- add `Shift+P` shortcut to set a property on the focused tray

## Testing
- `npm run build`
