### PR TITLE
Fix decryption for legacy tray data

### DIFF
--- a/src/networks.ts
+++ b/src/networks.ts
@@ -166,12 +166,14 @@ export async function downloadData(tray: Tray) {
         throw new Error("Password required for encrypted data");
       }
       serialized = await decryptString(data.data, password);
-    } else {
+    } else if ("data" in data) {
       if (typeof data.data === "string") {
         serialized = data.data;
       } else {
         serialized = JSON.stringify(data.data);
       }
+    } else {
+      serialized = typeof data === "string" ? data : JSON.stringify(data);
     }
 
     const downloadedTray = deserialize(serialized);


### PR DESCRIPTION
## Summary
- support downloading trays saved in the old format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d916194d08324b9c3b137f52e8aa2