### PR TITLE
Add build step to Pages workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to install deps and build before upload

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683ddeb7d0108324b8059d9cf2a12ae0