### PR TITLE
Add TDD agent and example tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 trays
 past.txt
 tray_data.json
+cjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENT Instructions
+
+This project uses TypeScript and Node's built in test runner.
+
+* Before running tests, compile the TypeScript sources to a CommonJS directory named `cjs`.
+  Example:
+  ```bash
+  npx tsc --module commonjs --outDir cjs
+  ```
+* Run tests with:
+  ```bash
+  node --test
+  ```
+* Tests should use Node's `assert` module.
+* Provide simple stubs for any browser APIs (such as `document`, `window` or `fetch`) when testing functions that depend on them.
+* Mock network requests by replacing `global.fetch` with a stub during tests.
+* Ensure each new feature or bug fix includes relevant unit tests at the function level and, when applicable, tests simulating browser rendering.

--- a/test/notification.test.js
+++ b/test/notification.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+const timeouts = [];
+// override setTimeout to capture callbacks
+global.setTimeout = (fn, ms) => { timeouts.push(fn); return 1; };
+
+// minimal DOM
+const body = { children: [], appendChild(el){ this.children.push(el); }, removeChild(el){ this.children = this.children.filter(c=>c!==el); } };
+const doc = { body, createElement(tag){ return { tagName:tag, style:{}, textContent:'', appendChild(){}, classList:{add(){}}, remove(){ body.removeChild(this); } }; } };
+const win = { addEventListener(){}, location:{ href:'', replace(){} } };
+
+global.document = doc;
+global.window = win;
+
+const { showUploadNotification } = require('../cjs/networks.js');
+
+test('showUploadNotification adds and removes element', () => {
+  const start = body.children.length;
+  showUploadNotification('Hello');
+  assert.strictEqual(body.children.length, start + 1);
+  const el = body.children[body.children.length - 1];
+  assert.strictEqual(el.textContent, 'Hello');
+  // run scheduled callbacks
+  while(timeouts.length) timeouts.shift()();
+  assert.strictEqual(body.children.length, start);
+});

--- a/test/uploadData.test.js
+++ b/test/uploadData.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+// stub DOM
+const body = { children: [], appendChild(el){ this.children.push(el); }, removeChild(el){ this.children = this.children.filter(c=>c!==el); } };
+const doc = { body, createElement(){ return { style:{}, textContent:'', appendChild(){}, classList:{add(){}} }; } };
+const win = { addEventListener(){}, location:{ href:'', replace(){} } };
+
+global.document = doc;
+global.window = win;
+
+const { uploadData } = require('../cjs/networks.js');
+
+test('uploadData calls fetch and shows notification', async () => {
+  let called;
+  global.fetch = async (url, opts) => { called = { url, opts }; return { ok:true, text: async ()=>'ok' }; };
+  const start = body.children.length;
+  await uploadData({ host_url:'http://x', filename:'f.json', id:'1', name:'t', children:[] });
+  assert.ok(called);
+  assert.strictEqual(called.url, 'http://x/tray/save');
+  assert.strictEqual(called.opts.method, 'POST');
+  const el = body.children[body.children.length - 1];
+  assert.strictEqual(el.textContent, 'Data uploaded successfully.');
+  assert.strictEqual(body.children.length, start + 1);
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+// setup minimal DOM before requiring utils
+const body = { children: [], appendChild(el){ this.children.push(el); }, removeChild(el){ this.children = this.children.filter(c=>c!==el); } };
+const doc = { body, createElement(){ return { style:{}, appendChild(){}, querySelector(){return null;} }; }, querySelector(){ return null; } };
+const win = { addEventListener(){}, location:{ href:'', replace(u){ this.href = u; } } };
+global.document = doc;
+global.window = win;
+
+const utils = require('../cjs/utils.js');
+
+test('generateUUID returns unique values', () => {
+  const a = utils.generateUUID();
+  const b = utils.generateUUID();
+  assert.match(a, /^[0-9a-f-]{36}$/);
+  assert.notStrictEqual(a, b);
+});
+
+test('getRandomColor format', () => {
+  const c = utils.getRandomColor();
+  assert.ok(/^#[0-9A-F]{6}$/.test(c));
+});
+
+test('getWhiteColor returns constant', () => {
+  assert.strictEqual(utils.getWhiteColor(), '#f5f5f5');
+});


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with instructions for compiling TypeScript and running tests
- ignore new `cjs` build directory
- add example tests using Node's built-in test runner

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_683df06797b48324afcf21c00fe9f3eb