### PR TITLE
Refactor menus and add tests

### DIFF
--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -10,13 +10,38 @@ import { Tray } from "./tray";
 import { fetchTrayList, setNetworkOption } from "./networks";
 import {
   meltTray,
-  // expandAll,
   deleteTray,
   pasteFromClipboardInto,
   showMarkdownOutput,
 } from "./functions";
 import { serialize, saveToIndexedDB } from "./io";
 import { cloneTray } from "./utils";
+
+export interface ContextMenuItem {
+  act: string;
+  label: string;
+}
+
+export const CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
+  { act: "fetchTrayFromServer", label: "Fetch Tray from Server" },
+  { act: "networkSetting", label: "Network Setting" },
+  { act: "openTrayInOther", label: "Open This in Other" },
+  { act: "toggleFlexDirection", label: "Toggle Flex Direction" },
+  { act: "meltTray", label: "Melt this Tray" },
+  { act: "expandAll", label: "Expand All" },
+  { act: "copy", label: "Copy" },
+  { act: "paste", label: "Paste" },
+  { act: "cut", label: "Cut" },
+  { act: "delete", label: "Remove" },
+  {
+    act: "add_fetch_networkTray_to_child",
+    label: "Add Fetch NetworkTray to Child",
+  },
+  { act: "add_child_from_localStorage", label: "Add Child from Local Storage" },
+  { act: "addProperty", label: "Set Property" },
+  { act: "sortChildren", label: "Sort Children" },
+  { act: "outputMarkdown", label: "Output as Markdown" },
+];
 
 function showSortDialog(tray: Tray) {
   const propSet = new Set<string>();
@@ -67,29 +92,30 @@ document.body.appendChild(menu);
 menu.style.display = "none";       // 初期は非表示
 
 // -- ビルド関数 --------------------------------------------------
-function buildMenu(): HTMLElement {
+export function buildMenu(): HTMLElement {
   const el = document.createElement("div");
   el.className = "context-menu";
-  el.tabIndex = -1;                // フォーカス可
+  el.tabIndex = -1; // フォーカス可
 
-  el.innerHTML = /* html */ `
-    <div class="menu-item" data-act="fetchTrayFromServer">Fetch Tray from Server</div>
-    <div class="menu-item" data-act="networkSetting">Network Setting</div>
-    <div class="menu-item" data-act="openTrayInOther">Open This in Other</div>
-    <div class="menu-item" data-act="toggleFlexDirection">Toggle Flex Direction</div>
-    <div class="menu-item" data-act="meltTray">Melt this Tray</div>
-    <div class="menu-item" data-act="expandAll">Expand All</div>
-    <div class="menu-item" data-act="copy">Copy</div>
-    <div class="menu-item" data-act="paste">Paste</div>
-    <div class="menu-item" data-act="cut">Cut</div>
-    <div class="menu-item" data-act="delete">Remove</div>
-    <div class="menu-item" data-act="add_fetch_networkTray_to_child">Add Fetch NetworkTray to Child</div>
-    <div class="menu-item" data-act="add_child_from_localStorage">Add Child from Local Storage</div>
-    <div class="menu-item" data-act="addProperty">Set Property</div>
-    <div class="menu-item" data-act="sortChildren">Sort Children</div>
-    <div class="menu-item" data-act="outputMarkdown">Output as Markdown</div>
-    <div class="menu-item"><input type="color" id="borderColorPicker" /></div>
-  `;
+  for (const item of CONTEXT_MENU_ITEMS) {
+    const div = document.createElement("div");
+    div.className = "menu-item";
+    if (!("dataset" in div)) {
+      (div as any).dataset = {};
+    }
+    (div as any).dataset.act = item.act;
+    div.textContent = item.label;
+    el.appendChild(div);
+  }
+
+  const colorDiv = document.createElement("div");
+  colorDiv.className = "menu-item";
+  const picker = document.createElement("input");
+  picker.type = "color";
+  picker.id = "borderColorPicker";
+  colorDiv.appendChild(picker);
+  el.appendChild(colorDiv);
+
   return el;
 }
 

--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -13,6 +13,30 @@ import { copyTray, deleteTray } from "./functions";
 
 export let selected_trays: Tray[] = [];
 
+export interface HamburgerMenuItem {
+  action: string;
+  label: string;
+}
+
+export const HAMBURGER_MENU_ITEMS: HamburgerMenuItem[] = [
+  { action: "reset", label: "トレイをリセット" },
+  { action: "save", label: "現在の状態を保存" },
+  { action: "load", label: "保存した状態を読み込む" },
+  { action: "export", label: "データのエクスポート" },
+  { action: "import", label: "データのインポート" },
+  { action: "set_default_server", label: "set_default_server" },
+  { action: "set_secret", label: "set_secret" },
+  {
+    action: "import_network_tray_directly_as_root",
+    label: "import_network_tray_directly_as_root",
+  },
+  { action: "editTitle", label: "ページタイトルを編集" },
+  { action: "uploadAll", label: "Upload All" },
+  { action: "downloadAll", label: "Download All" },
+  { action: "copySelected", label: "Copy selected" },
+  { action: "cutSelected", label: "Cut selected" },
+];
+
 function appendMenuItems(
   menu: HTMLElement,
   items: Array<{ action: string; label: string }>,
@@ -48,13 +72,6 @@ export function createHamburgerMenu() {
   const hamburger = document.createElement("div");
   hamburger.classList.add("hamburger-menu");
   hamburger.innerHTML = "☰";
-  // hamburger.style.position = 'fixed';
-  // hamburger.style.top = '10px';
-  // hamburger.style.right = '10px';
-  // hamburger.style.fontSize = '24px';
-  // hamburger.style.cursor = 'pointer';
-  // hamburger.style.zIndex = '1000';
-  // document.body.appendChild(hamburger);
   leftBar.appendChild(hamburger);
 
   const sessionButton = document.createElement("div");
@@ -69,31 +86,7 @@ export function createHamburgerMenu() {
   menu.style.display = "none";
   leftBar.appendChild(menu);
   menu.style.position = "fixed";
-  // menu.style.top = '40px';
-  // menu.style.right = '10px';
-  // menu.style.backgroundColor = 'white';
-  // menu.style.border = '1px solid #ccc';
-  // menu.style.borderRadius = '4px';
-  // menu.style.padding = '10px';
-  // menu.style.zIndex = '999';
-  appendMenuItems(menu, [
-    { action: "reset", label: "トレイをリセット" },
-    { action: "save", label: "現在の状態を保存" },
-    { action: "load", label: "保存した状態を読み込む" },
-    { action: "export", label: "データのエクスポート" },
-    { action: "import", label: "データのインポート" },
-    { action: "set_default_server", label: "set_default_server" },
-    { action: "set_secret", label: "set_secret" },
-    {
-      action: "import_network_tray_directly_as_root",
-      label: "import_network_tray_directly_as_root",
-    },
-    { action: "editTitle", label: "ページタイトルを編集" },
-    { action: "uploadAll", label: "Upload All" },
-    { action: "downloadAll", label: "Download All" },
-    { action: "copySelected", label: "Copy selected" },
-    { action: "cutSelected", label: "Cut selected" },
-  ]);
+  appendMenuItems(menu, HAMBURGER_MENU_ITEMS);
 
   document.body.appendChild(menu);
 

--- a/test/contextMenu.test.js
+++ b/test/contextMenu.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+// minimal DOM stubs
+const body = {
+  children: [],
+  appendChild(el) { this.children.push(el); el.parent = this; },
+  removeChild(el) { this.children = this.children.filter(c => c !== el); }
+};
+function createElement() {
+  const el = {
+    children: [],
+    style: {},
+    dataset: {},
+    classList: { add(){} },
+    appendChild(child){ child.parent = this; this.children.push(child); },
+    querySelector(selector){
+      if(selector === '#borderColorPicker'){
+        return this.children.flatMap(c=>c.children || []).find(c=>c.id === 'borderColorPicker') || null;
+      }
+      return null;
+    },
+    getBoundingClientRect(){ return { width:100, height:100 }; },
+    focus(){}
+  };
+  return el;
+}
+const documentStub = {
+  body,
+  createElement,
+  querySelector(){return null;},
+  addEventListener(){},
+  removeEventListener(){},
+};
+const windowStub = { innerWidth: 800, innerHeight: 600, addEventListener(){} };
+
+global.document = documentStub;
+global.window = windowStub;
+
+delete require.cache[require.resolve('../cjs/contextMenu.js')];
+const ctx = require('../cjs/contextMenu.js');
+
+test('buildMenu creates items', () => {
+  const m = ctx.buildMenu();
+  assert.strictEqual(m.children.length, ctx.CONTEXT_MENU_ITEMS.length + 1);
+});
+
+test('open and close context menu', () => {
+  const menuBefore = body.children.length;
+  const tray = { borderColor: '#000', changeBorderColor(){} };
+  class MouseEventStub{}
+  global.MouseEvent = MouseEventStub;
+  const ev = new MouseEventStub();
+  ev.clientX = 10; ev.clientY = 10;
+  ctx.openContextMenu(tray, ev);
+  assert.strictEqual(body.children.length, menuBefore + 1);
+  const menu = body.children[body.children.length - 1];
+  assert.strictEqual(menu.style.display, 'block');
+  ctx.closeContextMenu();
+  assert.strictEqual(menu.style.display, 'none');
+});

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+// DOM stubs
+const body = {
+  children: [],
+  appendChild(el){ this.children.push(el); el.parent = this; },
+  removeChild(el){ this.children = this.children.filter(c=>c!==el); }
+};
+function createElement(){
+  return {
+    children: [],
+    style: {},
+    dataset: {},
+    classList:{ add(){} },
+    appendChild(child){ child.parent=this; this.children.push(child); },
+    addEventListener(type,fn){ this['on'+type]=fn; },
+    getBoundingClientRect(){ return { right:0, top:0 }; },
+    querySelectorAll(sel){
+      if(sel === '.menu-item') return this.children.filter(c=>c.className==='menu-item');
+      return [];
+    }
+  };
+}
+const documentStub = {
+  body,
+  createElement,
+  querySelector(){return null;},
+  addEventListener(){},
+};
+const windowStub = { addEventListener(){} };
+
+global.window = windowStub;
+
+global.document = documentStub;
+
+delete require.cache[require.resolve('../cjs/hamburger.js')];
+const ham = require('../cjs/hamburger.js');
+
+test('createHamburgerMenu adds items', () => {
+  const { hamburger, menu } = ham.createHamburgerMenu();
+  assert.strictEqual(menu.children.length, ham.HAMBURGER_MENU_ITEMS.length);
+  // trigger click
+  hamburger.onclick({ stopPropagation(){} });
+  assert.strictEqual(menu.style.display, 'block');
+  hamburger.onclick({ stopPropagation(){} });
+  assert.strictEqual(menu.style.display, 'none');
+});


### PR DESCRIPTION
## Summary
- simplify context menu construction
- organize hamburger menu items
- add unit tests for menu rendering and behavior

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_683df51bdf3c8324bb6cfcadbc795c82