### PR TITLE
Add keyboard navigable context menu

### DIFF
--- a/src/keyboardInteraction.ts
+++ b/src/keyboardInteraction.ts
@@ -4,6 +4,7 @@ import store from "./store";
 import { Tray } from "./tray";
 import { getTrayFromId, toggleEditMode } from "./utils";
 import { selected_trays, cutSelected, copySelected, deleteSelected } from "./hamburger";
+import { openContextMenuKeyboard } from "./contextMenu";
 
 
 export function handleKeyDown(tray: Tray, event: KeyboardEvent): void {
@@ -98,6 +99,22 @@ export function handleKeyDown(tray: Tray, event: KeyboardEvent): void {
         showMarkdownOutput(tray)
         break
       }
+    case " ":
+      if (event.ctrlKey) {
+        event.preventDefault();
+        openContextMenuKeyboard(tray);
+      }
+      break;
+    case "ContextMenu":
+      event.preventDefault();
+      openContextMenuKeyboard(tray);
+      break;
+    case "F10":
+      if (event.shiftKey) {
+        event.preventDefault();
+        openContextMenuKeyboard(tray);
+      }
+      break;
     // case " ":
     //   if (event.ctrlKey) {
     //     event.preventDefault();

--- a/test/contextMenu.test.js
+++ b/test/contextMenu.test.js
@@ -12,7 +12,12 @@ function createElement() {
     children: [],
     style: {},
     dataset: {},
-    classList: { add(){} },
+    classList: {
+      _cls: new Set(),
+      add(c){ this._cls.add(c); },
+      remove(c){ this._cls.delete(c); },
+      contains(c){ return this._cls.has(c); }
+    },
     appendChild(child){ child.parent = this; this.children.push(child); },
     querySelector(selector){
       if(selector === '#borderColorPicker'){
@@ -20,7 +25,13 @@ function createElement() {
       }
       return null;
     },
+    querySelectorAll(sel){
+      if(sel === '.menu-item') return this.children.filter(c=>c.className==='menu-item');
+      return [];
+    },
     getBoundingClientRect(){ return { width:100, height:100 }; },
+    addEventListener(){},
+    removeEventListener(){},
     focus(){}
   };
   return el;
@@ -58,4 +69,13 @@ test('open and close context menu', () => {
   assert.strictEqual(menu.style.display, 'block');
   ctx.closeContextMenu();
   assert.strictEqual(menu.style.display, 'none');
+});
+
+test('keyboard navigation opens menu and focuses first item', () => {
+  const tray = { borderColor: '#000', changeBorderColor(){}, element:{ getBoundingClientRect(){ return { left:0, top:0, width:50, height:20 }; } } };
+  ctx.openContextMenuKeyboard(tray);
+  const menu = body.children[body.children.length - 1];
+  const first = menu.children[0];
+  assert.ok(first.classList.contains('focused'));
+  ctx.closeContextMenu();
 });


### PR DESCRIPTION
## Summary
- allow context menu opening via keyboard
- support arrow/enter navigation in the context menu
- expose helper for keyboard based menu opening
- test context menu keyboard behavior

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_683df6cd27508324b110a7d5cfad167f