### PR TITLE
Add new session option in hamburger menu

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -33,6 +33,7 @@ export const HAMBURGER_MENU_ITEMS: HamburgerMenuItem[] = [
   { action: "editTitle", label: "ページタイトルを編集" },
   { action: "uploadAll", label: "Upload All" },
   { action: "downloadAll", label: "Download All" },
+  { action: "newSession", label: "New Session" },
   { action: "copySelected", label: "Copy selected" },
   { action: "cutSelected", label: "Cut selected" },
 ];
@@ -132,6 +133,7 @@ export function createHamburgerMenu() {
     editTitle: editPageTitle,
     uploadAll: () => uploadAllData(),
     downloadAll: () => downloadAllData(),
+    newSession: openNewSession,
     cutSelected: cutSelected,
     copySelected: copySelected,
   };
@@ -270,6 +272,10 @@ async function showSessionList() {
     }
   });
   cancelBtn.addEventListener("click", () => dialog.remove());
+}
+
+export function openNewSession() {
+  window.location.href = `${window.location.pathname}?sessionId=new`;
 }
 
 function set_default_server() {

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -28,7 +28,10 @@ const documentStub = {
   querySelector(){return null;},
   addEventListener(){},
 };
-const windowStub = { addEventListener(){} };
+const windowStub = { 
+  addEventListener(){},
+  location:{ pathname:'/page', href:'' }
+};
 
 global.window = windowStub;
 
@@ -45,4 +48,9 @@ test('createHamburgerMenu adds items', () => {
   assert.strictEqual(menu.style.display, 'block');
   hamburger.onclick({ stopPropagation(){} });
   assert.strictEqual(menu.style.display, 'none');
+});
+
+test('new session menu updates location', () => {
+  ham.openNewSession();
+  assert.strictEqual(window.location.href, '/page?sessionId=new');
 });


### PR DESCRIPTION
## Summary
- support creating a new session from the hamburger menu
- test that the new session handler updates the location

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_683e0185efd083249e4386a505b15b4a