### PR TITLE
Implement UUID generation on new session

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -275,7 +275,8 @@ async function showSessionList() {
 }
 
 export function openNewSession() {
-  window.location.href = `${window.location.pathname}?sessionId=new`;
+  const id = generateUUID();
+  window.location.href = `${window.location.pathname}?sessionId=${id}`;
 }
 
 function set_default_server() {

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -52,5 +52,6 @@ test('createHamburgerMenu adds items', () => {
 
 test('new session menu updates location', () => {
   ham.openNewSession();
-  assert.strictEqual(window.location.href, '/page?sessionId=new');
+  const match = window.location.href.match(/\/page\?sessionId=([0-9a-f-]{36})$/);
+  assert.ok(match, 'location should include UUID');
 });


### PR DESCRIPTION
## Summary
- generate UUID directly when creating a new session
- update unit test for new session URL pattern

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_683e02750fec8324a87dc70f644132bb