### PR TITLE
Make tray names clickable when containing URLs

### DIFF
--- a/src/tray.ts
+++ b/src/tray.ts
@@ -113,7 +113,7 @@ export class Tray {
     const title = document.createElement("div");
     title.classList.add("tray-title");
     title.setAttribute("contenteditable", "false");
-    title.textContent = this.name;
+    this.updateTitleContent(title);
 
     const contextMenuButton = document.createElement("button");
     contextMenuButton.classList.add("tray-context-menu-button");
@@ -418,6 +418,28 @@ export class Tray {
     saveToIndexedDB();
   }
 
+  private isValidUrl(text: string): boolean {
+    try {
+      const u = new URL(text);
+      return u.protocol === "http:" || u.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }
+
+  private updateTitleContent(titleElement: HTMLDivElement) {
+    if (this.isValidUrl(this.name)) {
+      const a = document.createElement("a");
+      a.href = this.name;
+      a.textContent = this.name;
+      a.target = "_blank";
+      titleElement.innerHTML = "";
+      titleElement.appendChild(a);
+    } else {
+      titleElement.textContent = this.name;
+    }
+  }
+
   setupTitleEditing(titleElement: HTMLDivElement) {
     titleElement.addEventListener("dblclick", (event) => {
       event.stopPropagation();
@@ -491,7 +513,7 @@ export class Tray {
   startTitleEdit(titleElement: HTMLDivElement) {
     this.isEditing = true;
     titleElement.setAttribute("contenteditable", "true");
-    // titleElement.focus();
+    titleElement.textContent = this.name;
 
     const range = document.createRange();
     range.selectNodeContents(titleElement);
@@ -518,7 +540,7 @@ export class Tray {
   cancelTitleEdit(titleElement: HTMLDivElement) {
     this.isEditing = false;
     titleElement.setAttribute("contenteditable", "false");
-    titleElement.textContent = this.name;
+    this.updateTitleContent(titleElement);
   }
   onContextMenuButtonClick(event: MouseEvent) {
     event.preventDefault();
@@ -533,7 +555,7 @@ export class Tray {
   finishTitleEdit(titleElement: HTMLDivElement) {
     titleElement.setAttribute("contenteditable", "false");
     this.name = (titleElement.textContent || "").trim();
-    titleElement.textContent = this.name;
+    this.updateTitleContent(titleElement);
     // titleElement.removeEventListener("keydown", this.keyDownHandler);
     // titleElement.removeEventListener("blur", this.blurHandler);
     this.isEditing = false;

--- a/test/trayLink.test.js
+++ b/test/trayLink.test.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+const body = { children: [], appendChild(el){ this.children.push(el); el.parent=this; }, removeChild(){}}
+
+function createElement(tag='div'){
+  const el = {
+    tagName: tag.toUpperCase(),
+    children: [],
+    style: {},
+    dataset: {},
+    classList: {
+      _cls: new Set(),
+      add(c){ this._cls.add(c); },
+      contains(c){ return this._cls.has(c); }
+    },
+    appendChild(child){ child.parent=this; this.children.push(child); },
+    append(child){ this.appendChild(child); },
+    setAttribute(){},
+    addEventListener(){},
+    querySelector(sel){
+      if(sel.startsWith('.')){
+        const cls = sel.slice(1);
+        if(this.classList.contains(cls)) return this;
+        for(const ch of this.children){ const r = ch.querySelector(sel); if(r) return r; }
+      }
+      return null;
+    },
+    textContent: ''
+  };
+  if(tag === 'a') el.href = '';
+  if(tag === 'input') el.type = '';
+  return el;
+}
+
+const documentStub = { 
+  body, 
+  createElement, 
+  querySelector(){return null;},
+  createRange(){ return { selectNodeContents(){}, }; }
+};
+const windowStub = { 
+  addEventListener(){}, 
+  location:{},
+  getSelection(){ return { removeAllRanges(){}, addRange(){} }; }
+};
+
+global.document = documentStub;
+global.window = windowStub;
+global.indexedDB = { open(){ return { result:{ objectStoreNames:{ contains(){return false;}}, createObjectStore(){}, transaction(){ return { objectStore(){ return { put(){ return { onsuccess:null }; } }; } }; }}, onupgradeneeded:null, onsuccess:null, onerror:null }; } };
+
+// stub saveToIndexedDB before loading Tray
+delete require.cache[require.resolve('../cjs/io.js')];
+const io = require('../cjs/io.js');
+io.saveToIndexedDB = () => Promise.resolve('');
+
+// reload module with stubs
+delete require.cache[require.resolve('../cjs/tray.js')];
+const { Tray } = require('../cjs/tray.js');
+
+test('tray name as url renders anchor', () => {
+  const t = new Tray('0','1','https://example.com');
+  const title = t.element.querySelector('.tray-title');
+  const a = title.children[0];
+  assert.ok(a);
+  assert.strictEqual(a.href, 'https://example.com');
+});
+
+test('finishTitleEdit converts to link', () => {
+  const t = new Tray('0','2','first');
+  let title = t.element.querySelector('.tray-title');
+  t.startTitleEdit(title);
+  title.textContent = 'https://foo.com';
+  t.finishTitleEdit(title);
+  title = t.element.querySelector('.tray-title');
+  const a = title.children[0];
+  assert.ok(a);
+  assert.strictEqual(a.href, 'https://foo.com');
+});
+
+test('non url name stays text', () => {
+  const t = new Tray('0','3','hello');
+  const title = t.element.querySelector('.tray-title');
+  assert.strictEqual(title.textContent, 'hello');
+});


### PR DESCRIPTION
## Summary
- convert tray names to links if they're valid URLs
- adjust title editing logic to preserve and show anchors
- add unit tests for clickable name behavior

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_683e162fbb908324bc709e6274892487