### PR TITLE
Add markdown copy and download actions

### DIFF
--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -12,7 +12,8 @@ import {
   meltTray,
   deleteTray,
   pasteFromClipboardInto,
-  showMarkdownOutput,
+  copyMarkdownToClipboard,
+  downloadMarkdown,
 } from "./functions";
 import { serialize, saveToIndexedDB } from "./io";
 import { cloneTray } from "./utils";
@@ -40,7 +41,8 @@ export const CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
   { act: "add_child_from_localStorage", label: "Add Child from Local Storage" },
   { act: "addProperty", label: "Set Property" },
   { act: "sortChildren", label: "Sort Children" },
-  { act: "outputMarkdown", label: "Output as Markdown" },
+  { act: "copyMarkdown", label: "Copy Markdown" },
+  { act: "downloadMarkdown", label: "Download Markdown" },
 ];
 
 function showSortDialog(tray: Tray) {
@@ -282,8 +284,12 @@ function executeMenuAction(tray: Tray, act: string) {
       break;
 
 
-    case "outputMarkdown":
-      showMarkdownOutput(tray)
+    case "copyMarkdown":
+      copyMarkdownToClipboard(tray);
+      break;
+
+    case "downloadMarkdown":
+      downloadMarkdown(tray);
       break;
 
     case "fetchTrayFromServer":

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -72,6 +72,25 @@ export function showMarkdownOutput(tray: Tray) {
         `);
 }
 
+export function copyMarkdownToClipboard(tray: Tray) {
+  const markdown = outputAsMarkdown(tray);
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(markdown).catch(() => {});
+  }
+}
+
+export function downloadMarkdown(tray: Tray) {
+  const markdown = outputAsMarkdown(tray);
+  const blob = new Blob([markdown], { type: "text/markdown" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = "tray_structure.md";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
 
 export function getEventCoordinates(
   event: MouseEvent | TouchEvent,

--- a/src/keyboardInteraction.ts
+++ b/src/keyboardInteraction.ts
@@ -1,5 +1,5 @@
 
-import { copyTray, cutTray, deleteTray, pasteFromClipboardInto, showMarkdownOutput } from "./functions";
+import { copyTray, cutTray, deleteTray, pasteFromClipboardInto, copyMarkdownToClipboard } from "./functions";
 import store from "./store";
 import { Tray } from "./tray";
 import { getTrayFromId, toggleEditMode } from "./utils";
@@ -96,7 +96,7 @@ export function handleKeyDown(tray: Tray, event: KeyboardEvent): void {
     case "m":
       if (event.ctrlKey){
         event.preventDefault();
-        showMarkdownOutput(tray)
+        copyMarkdownToClipboard(tray);
         break
       }
     case " ":

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+// minimal DOM and clipboard stubs
+let clipboardText;
+const navigatorStub = { clipboard: { writeText(t){ clipboardText = t; return Promise.resolve(); } } };
+const body = {
+  children: [],
+  appendChild(el){ this.children.push(el); el.parent = this; },
+  removeChild(el){ this.children = this.children.filter(c=>c!==el); }
+};
+function createElement(tag){
+  const el = {
+    children: [],
+    style: {},
+    dataset: {},
+    classList:{
+      _cls: new Set(),
+      add(c){ this._cls.add(c); },
+      remove(c){ this._cls.delete(c); },
+      contains(c){ return this._cls.has(c); }
+    },
+    appendChild(child){ child.parent=this; this.children.push(child); },
+    querySelector(){ return null; },
+    querySelectorAll(){ return []; },
+    getBoundingClientRect(){ return { width:100, height:100 }; },
+    addEventListener(){},
+    removeEventListener(){},
+    focus(){}
+  };
+  if(tag === 'a'){
+    el.href = '';
+    el.download = '';
+    el.clickCalled = false;
+    el.click = function(){ this.clickCalled = true; };
+  }
+  return el;
+}
+let createdAnchor;
+const documentStub = {
+  body,
+  createElement(tag){
+    const el = createElement(tag);
+    if(tag === 'a') createdAnchor = el;
+    return el;
+  },
+  querySelector(){return null;},
+  addEventListener(){},
+  removeEventListener(){},
+};
+const urlStub = { createObjectURL(){ return 'blob:1'; }, revokeObjectURL(){} };
+const windowStub = { addEventListener(){}, location:{ href:'', replace(){}, pathname:'' } };
+
+Object.defineProperty(global, 'navigator', { configurable: true, value: navigatorStub });
+global.document = documentStub;
+global.URL = urlStub;
+global.window = windowStub;
+
+delete require.cache[require.resolve('../cjs/functions.js')];
+const fns = require('../cjs/functions.js');
+
+test('copyMarkdownToClipboard writes markdown', async () => {
+  clipboardText = undefined;
+  const tray = { name:'root', children:[{ name:'child', children:[] }] };
+  await fns.copyMarkdownToClipboard(tray);
+  assert.strictEqual(clipboardText, '- root\n  - child\n');
+});
+
+test('downloadMarkdown triggers anchor click', () => {
+  createdAnchor = undefined;
+  const tray = { name:'root', children:[] };
+  const start = body.children.length;
+  fns.downloadMarkdown(tray);
+  assert.ok(createdAnchor.clickCalled);
+  assert.strictEqual(createdAnchor.download, 'tray_structure.md');
+  assert.strictEqual(createdAnchor.href, 'blob:1');
+  assert.strictEqual(body.children.length, start);
+});


### PR DESCRIPTION
## Summary
- add `copyMarkdownToClipboard` and `downloadMarkdown` helpers
- hook `Ctrl+M` to copy markdown
- show `Copy Markdown` and `Download Markdown` in the context menu
- add unit tests for new markdown helpers

## Testing
- `npx tsc --module commonjs --outDir cjs`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_683e18c1acc08324a061691356a73bfd