### PR TITLE
Implement auto upload sync

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,8 @@ import {
   uploadData,
   fetchTrayList,
   setNetworkOption,
+  startAutoUpload,
+  syncTray,
 } from "./networks";
 import { meltTray } from "./functions";
 import { Tray, TrayId } from "./tray";
@@ -33,7 +35,7 @@ const TRAY_DATA_KEY = "trayData";
 // export const globalLabelManager = new LabelManager();
 
 
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
   // const actionButtons = createActionButtons();
   // Attempt alternative insertion if needed
   // document.body.appendChild(actionButtons);
@@ -45,15 +47,24 @@ window.addEventListener("DOMContentLoaded", () => {
     );
   }
   if (sessionId) {
-    loadFromIndexedDB(sessionId);
+    await loadFromIndexedDB(sessionId);
   } else {
-    loadFromIndexedDB();
+    await loadFromIndexedDB();
   }
   console.log("loaded");
   if (sessionId) {
     const savedTitle = localStorage.getItem(sessionId + "_title");
     if (savedTitle) {
       document.title = savedTitle;
+    }
+  }
+
+  const root = getRootElement();
+  if (root) {
+    const tray = element2TrayMap.get(root as HTMLElement) as Tray;
+    if (tray) {
+      await syncTray(tray);
+      startAutoUpload(tray);
     }
   }
 

--- a/test/autoUpload.test.js
+++ b/test/autoUpload.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+const body = { children: [], appendChild(el){ this.children.push(el); }, removeChild(el){ this.children = this.children.filter(c=>c!==el); } };
+const doc = { body, createElement(){ return { style:{}, textContent:'', appendChild(){}, classList:{add(){}}, remove(){ body.removeChild(this); } }; } };
+const win = { addEventListener(){}, location:{ href:'', replace(){} } };
+global.document = doc;
+global.window = win;
+
+function load(stubs){
+  Object.keys(stubs).forEach(m=>{
+    require.cache[require.resolve('../cjs/'+m+'.js')] = { exports: stubs[m] };
+  });
+  delete require.cache[require.resolve('../cjs/networks.js')];
+  return require('../cjs/networks.js');
+}
+
+test('newestTimestamp finds latest date', () => {
+  const { newestTimestamp } = load({io:{}, utils:{}, functions:{}});
+  const tree = {created_dt:new Date('2020-01-01'),children:[
+    {created_dt:new Date('2020-01-03'),children:[]},
+    {created_dt:new Date('2020-01-02'),children:[{created_dt:new Date('2020-01-04'),children:[]}]}
+  ]};
+  const ts = newestTimestamp(tree);
+  assert.strictEqual(new Date(ts).toISOString(), new Date('2020-01-04').toISOString());
+});
+
+test('syncTray adopts newer remote data', async () => {
+  let posted = false;
+  global.fetch = async (url, opts)=>{
+    if(opts.method==='GET') return { ok:true, json: async ()=>({id:'1',parentId:'p',name:'r',created_dt:new Date('2020-02-01'),children:[]}) };
+    if(opts.method==='POST'){ posted=true; return {ok:true,text:async()=>''}; }
+  };
+  const parent = {child:null,removed:null,addChild(t){this.child=t;},updateAppearance(){}};
+  const tray = {id:'1',parentId:'p',host_url:'u',filename:'f',created_dt:new Date('2020-01-01'),children:[],element:{remove(){}}};
+  const nets = load({io:{serialize:JSON.stringify,deserialize:JSON.parse},utils:{getTrayFromId:()=>parent},functions:{deleteTray:t=>{parent.removed=t;}}});
+  await nets.syncTray(tray);
+  assert.ok(parent.child); // replaced
+  assert.strictEqual(posted,false);
+});
+
+test('syncTray uploads when local newer', async () => {
+  let posted = false;
+  global.fetch = async (url, opts)=>{
+    if(opts.method==='GET') return { ok:true, json: async ()=>({id:'1',parentId:'p',name:'r',created_dt:new Date('2020-01-01'),children:[]}) };
+    if(opts.method==='POST'){ posted=true; return {ok:true,text:async()=>''}; }
+  };
+  const parent = {child:null,removed:null,addChild(t){this.child=t;},updateAppearance(){}};
+  const tray = {id:'1',parentId:'p',host_url:'u',filename:'f',created_dt:new Date('2020-02-01'),children:[],element:{remove(){}}};
+  const nets = load({io:{serialize:JSON.stringify,deserialize:JSON.parse},utils:{getTrayFromId:()=>parent},functions:{deleteTray:t=>{parent.removed=t;}}});
+  await nets.syncTray(tray);
+  assert.strictEqual(parent.child,null);
+  assert.strictEqual(posted,true);
+});


### PR DESCRIPTION
## Summary
- add auto upload logic with `syncTray` and `startAutoUpload`
- hook auto upload in app on load
- test auto upload and timestamp helper

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_683f7854e94483249ddff05c4b6c1b8d