### PR TITLE
Add autoupload toggle

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,7 +64,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     const tray = element2TrayMap.get(root as HTMLElement) as Tray;
     if (tray) {
       await syncTray(tray);
-      startAutoUpload(tray);
+      if (tray.autoUpload) startAutoUpload(tray);
     }
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -372,6 +372,11 @@
   text-align: left;
 }
 
+.network-tray-buttons button.auto-upload-on {
+  background-color: green;
+  color: white;
+}
+
 .network-tray-buttons button:hover {
   background-color: #e0e0e0;
 }

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -15,6 +15,8 @@ import {
   fetchTrayList,
   setNetworkOption,
   addTrayFromServer,
+  startAutoUpload,
+  stopAutoUpload,
 } from "./networks";
 import { meltTray } from "./functions";
 import { id2TrayData, element2TrayMap} from "./app";
@@ -38,6 +40,8 @@ export class Tray {
   filename: string | null;
   isFolded: boolean;
   properties: Record<string, any>;
+
+  autoUpload: boolean;
 
   isEditing: boolean;
   isSelected: boolean;
@@ -67,6 +71,7 @@ export class Tray {
     this.filename = filename;
     this.flexDirection = flexDirection;
     this.properties = properties;
+    this.autoUpload = false;
     // this.element = this.createElement();
     // this.element = null
     this.isEditing = false;
@@ -217,22 +222,19 @@ export class Tray {
     downloadButton.textContent = "Download";
     downloadButton.addEventListener("click", (e) => {
       if ((this.host_url)&&(this.filename)){
-        addTrayFromServer(getTrayFromId(this.parentId) as Tray,this.host_url,this.filename)}})      
+        addTrayFromServer(getTrayFromId(this.parentId) as Tray,this.host_url,this.filename)}})
 
-    // const autoUploadButton = document.createElement("button");
-    // autoUploadButton.textContent = `Auto Upload: ${
-    //   this.autoUpload ? "On" : "Off"
-    // }`;
-    // autoUploadButton.style.backgroundColor = this.autoUpload ? "green" : "";
-    // autoUploadButton.style.color = this.autoUpload ? "white" : "";
-    // autoUploadButton.addEventListener("click", () => this.toggleAutoUpload());
+    const autoUploadButton = document.createElement("button");
+    autoUploadButton.textContent = `Auto Upload: ${this.autoUpload ? "On" : "Off"}`;
+    if (this.autoUpload) autoUploadButton.classList.add("auto-upload-on");
+    autoUploadButton.addEventListener("click", () => this.toggleAutoUpload(autoUploadButton));
 
     // Add buttons to the container
     buttonContainer.appendChild(urlButton);
     buttonContainer.appendChild(filenameElement);
     buttonContainer.appendChild(uploadButton);
     buttonContainer.appendChild(downloadButton);
-    // buttonContainer.appendChild(autoUploadButton);
+    buttonContainer.appendChild(autoUploadButton);
 
     titleContainer.appendChild(networkInfoElement);
     if (this.filename != null) {
@@ -315,6 +317,23 @@ export class Tray {
     this.updateFlexDirection();
     this.updateChildrenAppearance(); // Add this line
     saveToIndexedDB();
+  }
+
+  toggleAutoUpload(button?: HTMLButtonElement) {
+    this.autoUpload = !this.autoUpload;
+    if (this.autoUpload) {
+      startAutoUpload(this);
+    } else {
+      stopAutoUpload(this);
+    }
+    if (button) {
+      button.textContent = `Auto Upload: ${this.autoUpload ? "On" : "Off"}`;
+      if (this.autoUpload) {
+        button.classList.add("auto-upload-on");
+      } else {
+        button.classList.remove("auto-upload-on");
+      }
+    }
   }
 
   setupEventListeners(element: HTMLElement): void {

--- a/test/autoUpload.test.js
+++ b/test/autoUpload.test.js
@@ -52,3 +52,18 @@ test('syncTray uploads when local newer', async () => {
   assert.strictEqual(parent.child,null);
   assert.strictEqual(posted,true);
 });
+
+test('startAutoUpload schedules sync and stopAutoUpload clears it', () => {
+  let callback;
+  let cleared;
+  global.setInterval = (fn, ms) => { callback = fn; return 123; };
+  global.clearInterval = id => { cleared = id; };
+  win.setInterval = global.setInterval;
+  win.clearInterval = global.clearInterval;
+  const nets = load({io:{serialize:JSON.stringify,deserialize:JSON.parse},utils:{getTrayFromId:()=>({})},functions:{deleteTray(){}}});
+  const tray = {id:'1',parentId:'p',host_url:'u',filename:'f',created_dt:new Date(),children:[],element:{remove(){}}};
+  nets.startAutoUpload(tray);
+  assert.ok(callback);
+  nets.stopAutoUpload(tray);
+  assert.strictEqual(cleared,123);
+});


### PR DESCRIPTION
## Summary
- add per-tray auto upload option and button
- style enabled state for auto-upload button
- manage multiple auto upload timers
- toggle automatic uploads for root only when enabled
- test scheduling and cancellation of auto upload

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_683f7c4789688324b21cdc4132962cee