### PR TITLE
Add indent/outdent keyboard shortcuts

### DIFF
--- a/src/keyboardInteraction.ts
+++ b/src/keyboardInteraction.ts
@@ -41,6 +41,16 @@ export function handleKeyDown(tray: Tray, event: KeyboardEvent): void {
     tray.moveDown();
     return;
   }
+  if (event.ctrlKey && event.key === "ArrowRight") {
+    event.preventDefault();
+    tray.indentRight();
+    return;
+  }
+  if (event.ctrlKey && event.key === "ArrowLeft") {
+    event.preventDefault();
+    tray.indentLeft();
+    return;
+  }
   switch (event.key) {
     case "ArrowUp":
       event.preventDefault();

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -797,6 +797,60 @@ export class Tray {
     this.element.focus();
   }
 
+  indentRight() {
+    const parent = getTrayFromId(this.parentId) as Tray | undefined;
+    if (!parent) return;
+    const index = parent.children.indexOf(this);
+    const next = parent.children[index + 1];
+    if (!next) return;
+
+    parent.removeChild(this.id);
+    next.addChild(this);
+    next.isFolded = false;
+    next.updateAppearance();
+
+    if (parent.children.length === 0) {
+      parent.updateAppearance();
+    }
+
+    this.element.focus();
+    saveToIndexedDB();
+  }
+
+  indentLeft() {
+    const parent = getTrayFromId(this.parentId) as Tray | undefined;
+    if (!parent) return;
+    const grand = getTrayFromId(parent.parentId) as Tray | undefined;
+    if (!grand) return;
+
+    const parentIndex = grand.children.indexOf(parent);
+
+    parent.removeChild(this.id);
+
+    this.parentId = grand.id;
+    grand.children.splice(parentIndex + 1, 0, this);
+
+    const gpContent = grand.element.querySelector(
+      ".tray-content"
+    ) as HTMLElement | null;
+    if (gpContent) {
+      gpContent.insertBefore(this.element, parent.element.nextSibling);
+    }
+
+    if (grand.children.length === 1) {
+      const color =
+        grand.borderColor == getWhiteColor()
+          ? getRandomColor()
+          : grand.borderColor;
+      grand.borderColor = color;
+      grand.updateBorderColor(grand.borderColor);
+    }
+
+    grand.updateAppearance();
+    this.element.focus();
+    saveToIndexedDB();
+  }
+
   // Default to ascending order
   sortChildren(property: string = "created_dt", descending: boolean = false) {
     this.children.sort((a, b) => {

--- a/test/moveTray.test.js
+++ b/test/moveTray.test.js
@@ -132,3 +132,34 @@ test('ctrl+ArrowUp keeps focus on moved tray', () => {
 
   assert.strictEqual(focused, target.element);
 });
+
+test('ctrl+ArrowRight nests tray under next sibling', () => {
+  const parent = new Tray('0','p5','parent');
+  idMap.set(parent.id, parent);
+  const first = new Tray(parent.id,'f5','F'); idMap.set(first.id, first);
+  const target = new Tray(parent.id,'t5','T'); idMap.set(target.id, target);
+  const next = new Tray(parent.id,'n5','N'); idMap.set(next.id, next);
+  parent.addChild(next);
+  parent.addChild(target);
+  parent.addChild(first); // order first, target, next
+
+  ki.handleKeyDown(target, { key:'ArrowRight', ctrlKey:true, preventDefault(){}, stopPropagation(){} });
+
+  assert.ok(!parent.children.includes(target));
+  assert.strictEqual(next.children[0], target);
+  assert.strictEqual(target.parentId, next.id);
+});
+
+test('ctrl+ArrowLeft moves tray to parent level', () => {
+  const root = new Tray('0','root','root'); idMap.set(root.id, root);
+  const parent = new Tray(root.id,'p6','parent'); idMap.set(parent.id, parent);
+  const target = new Tray(parent.id,'t6','T'); idMap.set(target.id, target);
+  root.addChild(parent);
+  parent.addChild(target);
+
+  ki.handleKeyDown(target, { key:'ArrowLeft', ctrlKey:true, preventDefault(){}, stopPropagation(){} });
+
+  assert.ok(!parent.children.includes(target));
+  assert.strictEqual(root.children[1], target);
+  assert.strictEqual(target.parentId, root.id);
+});


### PR DESCRIPTION
## Summary
- add `indentRight` and `indentLeft` methods in `Tray`
- trigger new methods with Ctrl+ArrowRight and Ctrl+ArrowLeft
- test indent and outdent behaviour

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68401715f8d483249ef9f67ff3ca9b30