### PR TITLE
Add expand children menu

### DIFF
--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -16,7 +16,7 @@ import {
   downloadMarkdown,
 } from "./functions";
 import { serialize, saveToIndexedDB } from "./io";
-import { cloneTray } from "./utils";
+import { cloneTray, expandChildrenOneLevel } from "./utils";
 
 export interface ContextMenuItem {
   act: string;
@@ -30,6 +30,7 @@ export const CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
   { act: "toggleFlexDirection", label: "Toggle Flex Direction" },
   { act: "meltTray", label: "Melt this Tray" },
   { act: "expandAll", label: "Expand All" },
+  { act: "expandChildrenOneLevel", label: "Expand Children 1 Level" },
   { act: "copy", label: "Copy" },
   { act: "paste", label: "Paste" },
   { act: "cut", label: "Cut" },
@@ -278,6 +279,9 @@ function executeMenuAction(tray: Tray, act: string) {
     // case "expandAll":
     //   expandAll(tray);
     //   break;
+    case "expandChildrenOneLevel":
+      expandChildrenOneLevel(tray);
+      break;
 
     case "toggleFlexDirection":
       tray.toggleFlexDirection?.();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,3 +85,10 @@ export function expandAll(tray: Tray) {
   tray.children.map((t) => expandAll(t));
   tray.updateAppearance();
 }
+
+export function expandChildrenOneLevel(tray: Tray) {
+  tray.children.forEach((child) => {
+    child.isFolded = false;
+    child.updateAppearance();
+  });
+}

--- a/test/contextMenu.test.js
+++ b/test/contextMenu.test.js
@@ -56,6 +56,11 @@ test('buildMenu creates items', () => {
   assert.strictEqual(m.children.length, ctx.CONTEXT_MENU_ITEMS.length + 1);
 });
 
+test('menu items include expandChildrenOneLevel', () => {
+  const found = ctx.CONTEXT_MENU_ITEMS.some(i => i.act === 'expandChildrenOneLevel');
+  assert.ok(found);
+});
+
 test('open and close context menu', () => {
   const menuBefore = body.children.length;
   const tray = { borderColor: '#000', changeBorderColor(){} };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -25,3 +25,14 @@ test('getRandomColor format', () => {
 test('getWhiteColor returns constant', () => {
   assert.strictEqual(utils.getWhiteColor(), '#f5f5f5');
 });
+
+test('expandChildrenOneLevel expands direct children', () => {
+  const child1 = { isFolded: true, updateAppearance(){ this.updated = true; } };
+  const child2 = { isFolded: true, updateAppearance(){ this.updated = true; } };
+  const tray = { children: [child1, child2] };
+  utils.expandChildrenOneLevel(tray);
+  assert.strictEqual(child1.isFolded, false);
+  assert.strictEqual(child2.isFolded, false);
+  assert.ok(child1.updated);
+  assert.ok(child2.updated);
+});


### PR DESCRIPTION
## Summary
- add `expandChildrenOneLevel` helper
- expose new context menu action and label
- verify item existence and helper behavior via tests

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6840a0136da48324820b0437a12aa019