### PR TITLE
Refactor hamburger menu

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -18,7 +18,7 @@ export interface HamburgerMenuItem {
   label: string;
 }
 
-export const HAMBURGER_MENU_ITEMS: HamburgerMenuItem[] = [
+export const GENERAL_MENU_ITEMS: HamburgerMenuItem[] = [
   { action: "reset", label: "トレイをリセット" },
   { action: "save", label: "現在の状態を保存" },
   { action: "load", label: "保存した状態を読み込む" },
@@ -33,6 +33,9 @@ export const HAMBURGER_MENU_ITEMS: HamburgerMenuItem[] = [
   { action: "uploadAll", label: "Upload All" },
   { action: "downloadAll", label: "Download All" },
   { action: "newSession", label: "New Session" },
+];
+
+export const SELECTION_MENU_ITEMS: HamburgerMenuItem[] = [
   { action: "copySelected", label: "Copy selected" },
   { action: "cutSelected", label: "Cut selected" },
 ];
@@ -80,13 +83,25 @@ export function createHamburgerMenu() {
   leftBar.appendChild(sessionButton);
   sessionButton.addEventListener("click", showSessionList);
 
+  const selectionButton = document.createElement("div");
+  selectionButton.classList.add("selection-menu-button");
+  selectionButton.innerHTML = "✔";
+  leftBar.appendChild(selectionButton);
+
+  const selectionMenu = document.createElement("div");
+  selectionMenu.classList.add("selection-menu-items");
+  selectionMenu.style.display = "none";
+  leftBar.appendChild(selectionMenu);
+  selectionMenu.style.position = "fixed";
+  appendMenuItems(selectionMenu, SELECTION_MENU_ITEMS);
+
 
   const menu = document.createElement("div");
   menu.classList.add("hamburger-menu-items");
   menu.style.display = "none";
   leftBar.appendChild(menu);
   menu.style.position = "fixed";
-  appendMenuItems(menu, HAMBURGER_MENU_ITEMS);
+  appendMenuItems(menu, GENERAL_MENU_ITEMS);
 
   document.body.appendChild(menu);
 
@@ -110,11 +125,28 @@ export function createHamburgerMenu() {
     event.stopPropagation();
   });
 
+  selectionButton.addEventListener("click", (event) => {
+    selectionMenu.style.display =
+      selectionMenu.style.display === "none" ? "block" : "none";
+    if (selectionMenu.style.display === "block") {
+      const rect = leftBar.getBoundingClientRect();
+      selectionMenu.style.left = `${rect.right}px`;
+      selectionMenu.style.top = `${rect.top}px`;
+    }
+    event.stopPropagation();
+  });
+
   document.addEventListener("click", (event: MouseEvent) => {
     const target = event.target as HTMLElement;
 
-    if (!menu.contains(target) && target !== hamburger) {
+    if (
+      !menu.contains(target) &&
+      target !== hamburger &&
+      !selectionMenu.contains(target) &&
+      target !== selectionButton
+    ) {
       menu.style.display = "none";
+      selectionMenu.style.display = "none";
     }
   });
 
@@ -149,6 +181,18 @@ export function createHamburgerMenu() {
     menu.style.display = "none";
   });
 
+  selectionMenu.addEventListener("click", (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    const action = target.getAttribute("data-action") || "";
+
+    const handler = menuActions[action];
+    if (handler) {
+      handler();
+    }
+
+    selectionMenu.style.display = "none";
+  });
+
   // ホバー効果の追加
   menuItems.forEach((item) => {
     item.addEventListener("mouseover", () => {
@@ -159,7 +203,7 @@ export function createHamburgerMenu() {
     });
   });
 
-  return { hamburger, menu, leftBar };
+  return { hamburger, menu, selectionMenu, leftBar };
 }
 function editPageTitle() {
   const currentTitle = document.title;

--- a/src/styles.css
+++ b/src/styles.css
@@ -523,6 +523,13 @@ body > .tray > .tray-content {
   text-align: center;
 }
 
+.selection-menu-button {
+  padding: 10px;
+  font-size: 20px;
+  cursor: pointer;
+  text-align: center;
+}
+
 .session-selection-dialog {
   position: fixed;
   top: 50%;
@@ -556,6 +563,16 @@ body > .tray > .tray-content {
 }
 
 .hamburger-menu-items {
+  position: fixed;
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px;
+  z-index: 1001;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.selection-menu-items {
   position: fixed;
   background-color: white;
   border: 1px solid #ccc;

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -41,8 +41,9 @@ delete require.cache[require.resolve('../cjs/hamburger.js')];
 const ham = require('../cjs/hamburger.js');
 
 test('createHamburgerMenu adds items', () => {
-  const { hamburger, menu } = ham.createHamburgerMenu();
-  assert.strictEqual(menu.children.length, ham.HAMBURGER_MENU_ITEMS.length);
+  const { hamburger, menu, selectionMenu } = ham.createHamburgerMenu();
+  assert.strictEqual(menu.children.length, ham.GENERAL_MENU_ITEMS.length);
+  assert.strictEqual(selectionMenu.children.length, ham.SELECTION_MENU_ITEMS.length);
   // trigger click
   hamburger.onclick({ stopPropagation(){} });
   assert.strictEqual(menu.style.display, 'block');


### PR DESCRIPTION
## Summary
- split hamburger menu items into general and selection actions
- add a new selection menu button
- show selected-tray actions in its own menu
- style new selection menu elements
- update tests for new menu structure

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6840f5cf6b4c8324aeff1045280b255c