### PR TITLE
Update indentLeft behavior

### DIFF
--- a/src/tray.ts
+++ b/src/tray.ts
@@ -845,13 +845,13 @@ export class Tray {
     parent.removeChild(this.id);
 
     this.parentId = grand.id;
-    grand.children.splice(parentIndex + 1, 0, this);
+    grand.children.splice(parentIndex, 0, this);
 
     const gpContent = grand.element.querySelector(
       ".tray-content"
     ) as HTMLElement | null;
     if (gpContent) {
-      gpContent.insertBefore(this.element, parent.element.nextSibling);
+      gpContent.insertBefore(this.element, parent.element);
     }
 
     if (grand.children.length === 1) {

--- a/test/moveTray.test.js
+++ b/test/moveTray.test.js
@@ -150,7 +150,7 @@ test('ctrl+ArrowRight nests tray under next sibling', () => {
   assert.strictEqual(target.parentId, next.id);
 });
 
-test('ctrl+ArrowLeft moves tray to parent level', () => {
+test('ctrl+ArrowLeft moves tray above parent', () => {
   const root = new Tray('0','root','root'); idMap.set(root.id, root);
   const parent = new Tray(root.id,'p6','parent'); idMap.set(parent.id, parent);
   const target = new Tray(parent.id,'t6','T'); idMap.set(target.id, target);
@@ -160,6 +160,7 @@ test('ctrl+ArrowLeft moves tray to parent level', () => {
   ki.handleKeyDown(target, { key:'ArrowLeft', ctrlKey:true, preventDefault(){}, stopPropagation(){} });
 
   assert.ok(!parent.children.includes(target));
-  assert.strictEqual(root.children[1], target);
+  assert.strictEqual(root.children[0], target);
+  assert.strictEqual(root.children[1], parent);
   assert.strictEqual(target.parentId, root.id);
 });


### PR DESCRIPTION
## Summary
- tweak `indentLeft` so Ctrl+Left places tray above its parent
- update move tray test for new behavior

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6842075586048324b9897adaa366d106