### PR TITLE
Improve URL detection in Tray names

### DIFF
--- a/src/tray.ts
+++ b/src/tray.ts
@@ -455,22 +455,12 @@ export class Tray {
   }
 
   private isValidUrl(text: string): boolean {
-    try {
-      const u = new URL(text);
-      return u.protocol === "http:" || u.protocol === "https:";
-    } catch {
-      return false;
-    }
+    return /^https?:\/\/\S+/i.test(text);
   }
 
   private isImageUrl(text: string): boolean {
     if (text.startsWith("data:image/")) return true;
-    try {
-      const u = new URL(text);
-      return /\.(png|jpe?g|gif|bmp|svg)$/i.test(u.pathname);
-    } catch {
-      return false;
-    }
+    return /^https?:\/\/\S+\.(png|jpe?g|gif|bmp|svg)(\?.*)?$/i.test(text);
   }
 
   private updateTitleContent(titleElement: HTMLDivElement) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,12 +25,8 @@ export function getWhiteColor() {
 }
 
 export function getUrlParameter(name: string) {
-  name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-  var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
-  var results = regex.exec(location.search);
-  return results === null
-    ? ""
-    : decodeURIComponent(results[1].replace(/\+/g, " ")).trim();
+  const params = new URLSearchParams(window.location.search);
+  return (params.get(name) || "").trim();
 }
 export function getRootElement() {
   const rootTrayElement = document.querySelector("body > div.tray");

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -4,7 +4,7 @@ const { test } = require('node:test');
 // setup minimal DOM before requiring utils
 const body = { children: [], appendChild(el){ this.children.push(el); }, removeChild(el){ this.children = this.children.filter(c=>c!==el); } };
 const doc = { body, createElement(){ return { style:{}, appendChild(){}, querySelector(){return null;} }; }, querySelector(){ return null; } };
-const win = { addEventListener(){}, location:{ href:'', replace(u){ this.href = u; } } };
+const win = { addEventListener(){}, location:{ href:'', search:'', replace(u){ this.href = u; } } };
 global.document = doc;
 global.window = win;
 
@@ -35,4 +35,14 @@ test('expandChildrenOneLevel expands direct children', () => {
   assert.strictEqual(child2.isFolded, false);
   assert.ok(child1.updated);
   assert.ok(child2.updated);
+});
+
+test('getUrlParameter returns value when present', () => {
+  window.location.search = '?foo=bar&baz=qux';
+  assert.strictEqual(utils.getUrlParameter('baz'), 'qux');
+});
+
+test('getUrlParameter returns empty string when missing', () => {
+  window.location.search = '?foo=bar';
+  assert.strictEqual(utils.getUrlParameter('baz'), '');
 });


### PR DESCRIPTION
## Summary
- simplify `isValidUrl` and `isImageUrl` in `Tray`

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_684363ce8e708324aa240eed36b88eb3