### PR TITLE
Display tray timestamp when offline

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,12 @@
   box-shadow: 0 0 2px 2px rgba(0, 123, 255, 0.25); /* Custom focus indicator */
 }
 
+/* Created Time */
+.tray-created-time {
+  font-size: 0.6em;
+  color: #888;
+}
+
 /* Title */
 .tray-title {
   flex: 1;

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -237,10 +237,12 @@ export class Tray {
 
     networkContainer.appendChild(infoContainer);
     networkContainer.appendChild(actionsContainer);
-    networkContainer.appendChild(createdTime);
 
     if (this.filename != null) {
+      networkContainer.appendChild(createdTime);
       titleContainer.appendChild(networkContainer);
+    } else {
+      titleContainer.appendChild(createdTime);
     }
 
     titleContainer.style.display = "flex";


### PR DESCRIPTION
## Summary
- show tray creation time even when network features aren't configured
- style `.tray-created-time` for all trays

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6844c58dce248324a5aefbf3ff1445bb