### PR TITLE
Improve network tray buttons

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -368,7 +368,7 @@
 }
 
 .network-tray-buttons button {
-  font-size: 0.7em;
+  font-size: 1.2em;
   padding: 1px 3px;
   cursor: pointer;
   border: none;

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -227,7 +227,7 @@ export class Tray {
     });
 
     const autoUploadButton = document.createElement("button");
-    autoUploadButton.textContent = `♻️: ${this.autoUpload ? "On" : "Off"}`; // recycle icon
+    autoUploadButton.textContent = "♻️"; // recycle icon only
     if (this.autoUpload) autoUploadButton.classList.add("auto-upload-on");
     autoUploadButton.addEventListener("click", () => this.toggleAutoUpload(autoUploadButton));
 
@@ -348,7 +348,7 @@ export class Tray {
       stopAutoUpload(this);
     }
     if (button) {
-      button.textContent = `♻️: ${this.autoUpload ? "On" : "Off"}`;
+      button.textContent = "♻️";
       if (this.autoUpload) {
         button.classList.add("auto-upload-on");
       } else {


### PR DESCRIPTION
## Summary
- enlarge network tray button icons
- remove `:Off` from auto-upload text

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68466170e4148324a80ae1121a228d6c