### PR TITLE
Ensure new session opens in new window

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -344,7 +344,7 @@ async function showSessionList() {
 
 export function openNewSession() {
   const id = generateUUID();
-  window.location.href = `${window.location.pathname}?sessionId=${id}`;
+  window.open(`${window.location.pathname}?sessionId=${id}`, "_blank");
 }
 
 function set_default_server() {

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -28,9 +28,10 @@ const documentStub = {
   querySelector(){return null;},
   addEventListener(){},
 };
-const windowStub = { 
+const windowStub = {
   addEventListener(){},
-  location:{ pathname:'/page', href:'' }
+  location:{ pathname:'/page', href:'' },
+  open(url, target){ this.lastOpen = { url, target }; }
 };
 
 global.window = windowStub;
@@ -51,8 +52,10 @@ test('createHamburgerMenu adds items', () => {
   assert.strictEqual(menu.style.display, 'none');
 });
 
-test('new session menu updates location', () => {
+test('new session opens new window', () => {
   ham.openNewSession();
-  const match = window.location.href.match(/\/page\?sessionId=([0-9a-f-]{36})$/);
-  assert.ok(match, 'location should include UUID');
+  assert.ok(window.lastOpen, 'window.open should be called');
+  const match = window.lastOpen.url.match(/\/page\?sessionId=([0-9a-f-]{36})$/);
+  assert.ok(match, 'new window url should include UUID');
+  assert.strictEqual(window.lastOpen.target, '_blank');
 });


### PR DESCRIPTION
## Summary
- open new sessions in a separate window
- stub `window.open` in tests and check URL/target

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684c7b54a3c88324b9e87be2fb98fb62