### PR TITLE
Add Temporal Tray feature

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -56,6 +56,7 @@ export const GENERAL_MENU_ITEMS: HamburgerMenuItem[] = [
   { action: "uploadAll", label: "Upload All" },
   { action: "downloadAll", label: "Download All" },
   { action: "newSession", label: "New Session" },
+  { action: "temporalTray", label: "Temporal Tray" },
 ];
 
 export const SELECTION_MENU_ITEMS: HamburgerMenuItem[] = [
@@ -190,6 +191,7 @@ export function createHamburgerMenu() {
     uploadAll: () => uploadAllData(),
     downloadAll: () => downloadAllData(),
     newSession: openNewSession,
+    temporalTray: openTemporalTray,
     cutSelected: cutSelected,
     copySelected: copySelected,
   };
@@ -344,6 +346,12 @@ async function showSessionList() {
 
 export function openNewSession() {
   const id = generateUUID();
+  window.open(`${window.location.pathname}?sessionId=${id}`, "_blank");
+}
+
+export function openTemporalTray() {
+  const currentId = getUrlParameter("sessionId");
+  const id = currentId ? `temp-${currentId}` : `temp-${generateUUID()}`;
   window.open(`${window.location.pathname}?sessionId=${id}`, "_blank");
 }
 

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -30,7 +30,7 @@ const documentStub = {
 };
 const windowStub = {
   addEventListener(){},
-  location:{ pathname:'/page', href:'' },
+  location:{ pathname:'/page', href:'', search:'' },
   open(url, target){ this.lastOpen = { url, target }; }
 };
 
@@ -57,5 +57,13 @@ test('new session opens new window', () => {
   assert.ok(window.lastOpen, 'window.open should be called');
   const match = window.lastOpen.url.match(/\/page\?sessionId=([0-9a-f-]{36})$/);
   assert.ok(match, 'new window url should include UUID');
+  assert.strictEqual(window.lastOpen.target, '_blank');
+});
+
+test('temporal tray opens temp window for current session', () => {
+  window.location.search = '?sessionId=abc123';
+  ham.openTemporalTray();
+  assert.ok(window.lastOpen, 'window.open should be called');
+  assert.strictEqual(window.lastOpen.url, '/page?sessionId=temp-abc123');
   assert.strictEqual(window.lastOpen.target, '_blank');
 });


### PR DESCRIPTION
## Summary
- add a `Temporal Tray` item to the hamburger menu
- implement `openTemporalTray` to open a temp tray for the current session
- test that the temp tray uses the session's id

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_684c7fccf47c832491a15a0ad5c85662