### PR TITLE
Implement default sessionId

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,11 @@ export function getWhiteColor() {
 
 export function getUrlParameter(name: string) {
   const params = new URLSearchParams(window.location.search);
-  return (params.get(name) || "").trim();
+  const value = (params.get(name) || "").trim();
+  if (!value && name === "sessionId") {
+    return "default";
+  }
+  return value;
 }
 export function getRootElement() {
   const rootTrayElement = document.querySelector("body > div.tray");

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -46,3 +46,8 @@ test('getUrlParameter returns empty string when missing', () => {
   window.location.search = '?foo=bar';
   assert.strictEqual(utils.getUrlParameter('baz'), '');
 });
+
+test('getUrlParameter defaults sessionId to "default"', () => {
+  window.location.search = '';
+  assert.strictEqual(utils.getUrlParameter('sessionId'), 'default');
+});


### PR DESCRIPTION
## Summary
- ensure `getUrlParameter('sessionId')` returns `"default"` when not present
- verify defaulting logic with a new unit test

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684c827a65388324b57c31cbd9329acd