### PR TITLE
Fix data races when multiple tabs share session

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,13 @@ export const id2TrayData = new Map<TrayId, Tray>();
 
 const TRAY_DATA_KEY = "trayData";
 
+window.addEventListener("storage", (ev) => {
+  const sessionId = getUrlParameter("sessionId") || TRAY_DATA_KEY;
+  if (ev.key === `update_${sessionId}`) {
+    loadFromIndexedDB(sessionId);
+  }
+});
+
 // export const globalLabelManager = new LabelManager();
 
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -114,7 +114,14 @@ export async function saveToIndexedDB(
       putRequest.onsuccess = () => {
         console.log(keyToUse);
         console.log("Data saved successfully");
-        
+
+        try {
+          localStorage.setItem(
+            `update_${keyToUse}`,
+            Date.now().toString(),
+          );
+        } catch {}
+
         // Uncomment if auto-sync functionality is needed
         // if (AUTO_SYNC) {
         //   uploadAllData();

--- a/test/crossTabSync.test.js
+++ b/test/crossTabSync.test.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+const body = { appendChild(){}, children:[] };
+const documentStub = { body, createElement(){ return {}; }, querySelector(){ return null; } };
+const windowStub = {
+  events:{},
+  addEventListener(type, fn){ this.events[type] = fn; },
+  location:{ search:'?sessionId=abc123' }
+};
+
+global.document = documentStub;
+global.window = windowStub;
+
+global.localStorage = {
+  data:{},
+  setItem(key, val){ this.data[key] = val; this.last = { key, val }; },
+  getItem(key){ return this.data[key] || null; },
+  removeItem(key){ delete this.data[key]; }
+};
+
+let openReq, putReq;
+global.indexedDB = {
+  open(){
+    openReq = {
+      result:{
+        objectStoreNames:{ contains(){ return true; } },
+        createObjectStore(){},
+        transaction(){ return { objectStore(){ return { put(){ putReq = { onsuccess:null, onerror:null }; return putReq; } }; } }; }
+      },
+      onupgradeneeded:null,
+      onsuccess:null,
+      onerror:null
+    };
+    return openReq;
+  }
+};
+
+// stub modules before loading
+require.cache[require.resolve('../cjs/history.js')] = { exports:{ recordState(){} } };
+require.cache[require.resolve('../cjs/networks.js')] = { exports:{
+  downloadData(){}, showUploadNotification(){}, uploadData(){},
+  fetchTrayList(){}, setNetworkOption(){}, startAutoUpload(){}, syncTray(){}
+} };
+require.cache[require.resolve('../cjs/hamburger.js')] = { exports:{ createHamburgerMenu(){}, selected_trays:[] } };
+require.cache[require.resolve('../cjs/functions.js')] = { exports:{ meltTray(){} } };
+require.cache[require.resolve('../cjs/tray.js')] = { exports:{ Tray: class{} } };
+require.cache[require.resolve('../cjs/store.js')] = { exports:{} };
+require.cache[require.resolve('../cjs/state.js')] = { exports:{ setLastFocused(){} } };
+require.cache[require.resolve('../cjs/actionbotton.js')] = { exports:{ createActionButtons(){ return {}; } } };
+
+delete require.cache[require.resolve('../cjs/utils.js')];
+const utils = require('../cjs/utils.js');
+utils.getRootElement = () => ({ });
+
+delete require.cache[require.resolve('../cjs/io.js')];
+const io = require('../cjs/io.js');
+
+delete require.cache[require.resolve('../cjs/app.js')];
+require('../cjs/app.js');
+
+
+test('saveToIndexedDB notifies other tabs', async () => {
+  const p = io.saveToIndexedDB('abc123', '{}');
+  openReq.onsuccess();
+  putReq.onsuccess();
+  await p;
+  assert.strictEqual(global.localStorage.last.key, 'update_abc123');
+});
+
+test('storage event triggers reload', async () => {
+  let called = false;
+  io.loadFromIndexedDB = async (key) => { called = key; };
+  windowStub.events.storage({ key: 'update_abc123' });
+  assert.strictEqual(called, 'abc123');
+});


### PR DESCRIPTION
## Summary
- broadcast session updates via `localStorage` whenever saving to IndexedDB
- auto-reload a session when another tab updates it
- add regression test for cross-tab sync logic

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684c84c660448324b4d3b9231866fc34