### PR TITLE
Add parent tray insertion option

### DIFF
--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -29,6 +29,7 @@ export const CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
   { act: "removeFromServer", label: "Remove from Server" },
   { act: "openTrayInOther", label: "Open This in Other" },
   { act: "toggleFlexDirection", label: "Toggle Flex Direction" },
+  { act: "insertParentTray", label: "Insert Parent Tray" },
   { act: "meltTray", label: "Melt this Tray" },
   { act: "expandAll", label: "Expand All" },
   { act: "expandChildrenOneLevel", label: "Expand Children 1 Level" },
@@ -286,6 +287,10 @@ function executeMenuAction(tray: Tray, act: string) {
 
     case "toggleFlexDirection":
       tray.toggleFlexDirection?.();
+      break;
+
+    case "insertParentTray":
+      tray.insertParentTray?.();
       break;
 
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -862,6 +862,37 @@ export class Tray {
     saveToIndexedDB();
   }
 
+  insertParentTray() {
+    const parent = getTrayFromId(this.parentId) as Tray | undefined;
+    if (!parent) return;
+
+    const index = parent.children.indexOf(this);
+    if (index === -1) return;
+
+    const newTray = new Tray(parent.id, generateUUID(), "New Tray");
+
+    parent.children.splice(index, 1, newTray);
+
+    const content = parent.element.querySelector(
+      ".tray-content",
+    ) as HTMLElement | null;
+    if (content) {
+      content.insertBefore(newTray.element, this.element);
+    }
+
+    newTray.addChild(this);
+    parent.updateAppearance();
+    newTray.isFolded = false;
+    newTray.updateAppearance();
+
+    const titleElement = newTray.element.querySelector(
+      ".tray-title",
+    ) as HTMLDivElement;
+    newTray.startTitleEdit(titleElement);
+    newTray.element.focus();
+    saveToIndexedDB();
+  }
+
   // Default to ascending order
   sortChildren(property: string = "created_dt", descending: boolean = false) {
     this.children.sort((a, b) => {

--- a/test/contextMenu.test.js
+++ b/test/contextMenu.test.js
@@ -61,6 +61,11 @@ test('menu items include expandChildrenOneLevel', () => {
   assert.ok(found);
 });
 
+test('menu items include insertParentTray', () => {
+  const found = ctx.CONTEXT_MENU_ITEMS.some(i => i.act === 'insertParentTray');
+  assert.ok(found);
+});
+
 test('open and close context menu', () => {
   const menuBefore = body.children.length;
   const tray = { borderColor: '#000', changeBorderColor(){} };

--- a/test/focus.test.js
+++ b/test/focus.test.js
@@ -126,3 +126,16 @@ test('meltTray focuses parent tray', () => {
   assert.ok(!root.children.includes(child));
   assert.ok(root.children.includes(grand));
 });
+
+test('insertParentTray wraps tray correctly', () => {
+  const root = new Tray('0','r3','root'); idMap.set(root.id,root);
+  const child = new Tray(root.id,'c3','child'); idMap.set(child.id,child);
+  root.addChild(child);
+
+  child.insertParentTray();
+
+  const newParent = root.children[0];
+  assert.notStrictEqual(newParent, child);
+  assert.strictEqual(newParent.children[0], child);
+  assert.strictEqual(child.parentId, newParent.id);
+});


### PR DESCRIPTION
## Summary
- allow inserting a new tray between the parent and current tray
- expose this command from the context menu
- test the new menu item and wrapping behaviour

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_684c877e34e4832487279d7d9b65fe26