### PR TITLE
Add session ID edit option

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -55,6 +55,7 @@ export const GENERAL_MENU_ITEMS: HamburgerMenuItem[] = [
   { action: "editTitle", label: "ページタイトルを編集" },
   { action: "uploadAll", label: "Upload All" },
   { action: "downloadAll", label: "Download All" },
+  { action: "editSessionId", label: "セッションIDを編集" },
   { action: "newSession", label: "New Session" },
   { action: "temporalTray", label: "Temporal Tray" },
 ];
@@ -190,6 +191,7 @@ export function createHamburgerMenu() {
     editTitle: editPageTitle,
     uploadAll: () => uploadAllData(),
     downloadAll: () => downloadAllData(),
+    editSessionId: editSessionId,
     newSession: openNewSession,
     temporalTray: openTemporalTray,
     cutSelected: cutSelected,
@@ -245,6 +247,14 @@ function editPageTitle() {
       localStorage.setItem(sessionId + "_title", newTitle.trim());
       alert("ページタイトルを更新しました。");
     }
+  }
+}
+
+export function editSessionId() {
+  const currentId = getUrlParameter("sessionId");
+  const newId = prompt("新しいセッションIDを入力してください:", currentId || "");
+  if (newId && newId.trim() !== "") {
+    window.location.href = `${window.location.pathname}?sessionId=${newId.trim()}`;
   }
 }
 

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -67,3 +67,12 @@ test('temporal tray opens temp window for current session', () => {
   assert.strictEqual(window.lastOpen.url, '/page?sessionId=temp-abc123');
   assert.strictEqual(window.lastOpen.target, '_blank');
 });
+
+test('edit session id updates location', () => {
+  window.location.pathname = '/page';
+  window.location.search = '?sessionId=old';
+  global.prompt = () => 'new-id';
+  ham.editSessionId();
+  assert.strictEqual(window.location.href, '/page?sessionId=new-id');
+  global.prompt = undefined;
+});


### PR DESCRIPTION
## Summary
- add new `editSessionId` action and menu item
- support redirecting to a new session ID
- test hamburger menu session ID editing

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_684c8d92b1c88324a8aea0d4b7710faa