### PR TITLE
Add insert child tray feature

### DIFF
--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -30,6 +30,7 @@ export const CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
   { act: "openTrayInOther", label: "Open This in Other" },
   { act: "toggleFlexDirection", label: "Toggle Flex Direction" },
   { act: "insertParentTray", label: "Insert Parent Tray" },
+  { act: "insertChildTray", label: "Insert Child Tray" },
   { act: "meltTray", label: "Melt this Tray" },
   { act: "expandAll", label: "Expand All" },
   { act: "expandChildrenOneLevel", label: "Expand Children 1 Level" },
@@ -291,6 +292,10 @@ function executeMenuAction(tray: Tray, act: string) {
 
     case "insertParentTray":
       tray.insertParentTray?.();
+      break;
+
+    case "insertChildTray":
+      tray.insertChildTray?.();
       break;
 
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -893,6 +893,40 @@ export class Tray {
     saveToIndexedDB();
   }
 
+  insertChildTray() {
+    const oldChildren = [...this.children];
+    const content = this.element.querySelector(
+      ".tray-content",
+    ) as HTMLElement | null;
+    if (content) {
+      oldChildren.forEach((c) => content.removeChild(c.element));
+    }
+
+    this.children = [];
+    const newTray = new Tray(this.id, generateUUID(), "New Tray");
+    this.addChild(newTray);
+
+    const newContent = newTray.element.querySelector(
+      ".tray-content",
+    ) as HTMLElement | null;
+    oldChildren.forEach((child) => {
+      child.parentId = newTray.id;
+      newTray.children.push(child);
+      if (newContent) newContent.appendChild(child.element);
+    });
+
+    this.updateAppearance();
+    newTray.isFolded = false;
+    newTray.updateAppearance();
+
+    const titleElement = newTray.element.querySelector(
+      ".tray-title",
+    ) as HTMLDivElement;
+    newTray.startTitleEdit(titleElement);
+    newTray.element.focus();
+    saveToIndexedDB();
+  }
+
   // Default to ascending order
   sortChildren(property: string = "created_dt", descending: boolean = false) {
     this.children.sort((a, b) => {

--- a/test/contextMenu.test.js
+++ b/test/contextMenu.test.js
@@ -66,6 +66,11 @@ test('menu items include insertParentTray', () => {
   assert.ok(found);
 });
 
+test('menu items include insertChildTray', () => {
+  const found = ctx.CONTEXT_MENU_ITEMS.some(i => i.act === 'insertChildTray');
+  assert.ok(found);
+});
+
 test('open and close context menu', () => {
   const menuBefore = body.children.length;
   const tray = { borderColor: '#000', changeBorderColor(){} };

--- a/test/focus.test.js
+++ b/test/focus.test.js
@@ -139,3 +139,20 @@ test('insertParentTray wraps tray correctly', () => {
   assert.strictEqual(newParent.children[0], child);
   assert.strictEqual(child.parentId, newParent.id);
 });
+
+test('insertChildTray nests children correctly', () => {
+  const root = new Tray('0','r4','root'); idMap.set(root.id,root);
+  const child1 = new Tray(root.id,'c4','c1'); idMap.set(child1.id,child1);
+  const child2 = new Tray(root.id,'c5','c2'); idMap.set(child2.id,child2);
+  root.addChild(child1);
+  root.addChild(child2);
+
+  root.insertChildTray();
+
+  const newChild = root.children[0];
+  assert.notStrictEqual(newChild, child1);
+  assert.ok(newChild.children.includes(child1));
+  assert.ok(newChild.children.includes(child2));
+  assert.strictEqual(child1.parentId, newChild.id);
+  assert.strictEqual(child2.parentId, newChild.id);
+});


### PR DESCRIPTION
## Summary
- allow inserting an intermediate tray between a tray and its children
- expose `insertChildTray` via context menu
- test the new context menu item and nesting behaviour

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_684c8e164a1c8324b06b5694f3884de6