### PR TITLE
Implement global temporal tray

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -359,10 +359,13 @@ export function openNewSession() {
   window.open(`${window.location.pathname}?sessionId=${id}`, "_blank");
 }
 
+export const GLOBAL_TEMPORAL_TRAY_ID = "temp-global";
+
 export function openTemporalTray() {
-  const currentId = getUrlParameter("sessionId");
-  const id = currentId ? `temp-${currentId}` : `temp-${generateUUID()}`;
-  window.open(`${window.location.pathname}?sessionId=${id}`, "_blank");
+  window.open(
+    `${window.location.pathname}?sessionId=${GLOBAL_TEMPORAL_TRAY_ID}`,
+    "_blank",
+  );
 }
 
 function set_default_server() {

--- a/test/hamburger.test.js
+++ b/test/hamburger.test.js
@@ -60,11 +60,11 @@ test('new session opens new window', () => {
   assert.strictEqual(window.lastOpen.target, '_blank');
 });
 
-test('temporal tray opens temp window for current session', () => {
+test('temporal tray opens global temp window', () => {
   window.location.search = '?sessionId=abc123';
   ham.openTemporalTray();
   assert.ok(window.lastOpen, 'window.open should be called');
-  assert.strictEqual(window.lastOpen.url, '/page?sessionId=temp-abc123');
+  assert.strictEqual(window.lastOpen.url, '/page?sessionId=temp-global');
   assert.strictEqual(window.lastOpen.target, '_blank');
 });
 


### PR DESCRIPTION
## Summary
- define `GLOBAL_TEMPORAL_TRAY_ID` constant
- always use the global temporal tray session
- update tests for new global temporal tray behavior

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_684c8fa4feb083248e482734b08921cb