### PR TITLE
Add Google Drive storage support

### DIFF
--- a/src/googleDrive.ts
+++ b/src/googleDrive.ts
@@ -1,0 +1,77 @@
+declare const gapi: any;
+declare const google: any;
+
+export let tokenClient: any = null;
+let initialized = false;
+
+export async function initGoogleDrive(clientId: string) {
+  if (initialized) return;
+  await new Promise<void>((resolve, reject) => {
+    const g: any = (globalThis as any).gapi;
+    if (!g) {
+      const script = document.createElement('script');
+      script.src = 'https://apis.google.com/js/api.js';
+      script.onload = () => (globalThis as any).gapi.load('client', resolve);
+      script.onerror = () => reject(new Error('gapi load failed'));
+      document.body.appendChild(script);
+    } else {
+      g.load('client', resolve);
+    }
+  });
+  await (globalThis as any).gapi.client.load('drive', 'v3');
+  tokenClient = (globalThis as any).google.accounts.oauth2.initTokenClient({
+    client_id: clientId,
+    scope: 'https://www.googleapis.com/auth/drive.file',
+    callback: ''
+  });
+  initialized = true;
+}
+
+export function signIn() {
+  if (!initialized || !tokenClient) throw new Error('Google Drive not initialized');
+  return new Promise<void>((resolve, reject) => {
+    tokenClient.callback = (resp: any) => {
+      if (resp.error) reject(resp);
+      else resolve();
+    };
+    tokenClient.requestAccessToken();
+  });
+}
+
+export async function uploadToDrive(data: string, fileName: string, fileId?: string): Promise<string> {
+  await signIn();
+  const body = new Blob([data], { type: 'application/json' });
+  if (fileId) {
+    const res = await (globalThis as any).gapi.client.request({
+      path: `/upload/drive/v3/files/${fileId}`,
+      method: 'PATCH',
+      params: { uploadType: 'media' },
+      body
+    });
+    return res.result.id as string;
+  } else {
+    const res = await (globalThis as any).gapi.client.request({
+      path: '/upload/drive/v3/files',
+      method: 'POST',
+      params: { uploadType: 'media' },
+      body
+    });
+    const id = res.result.id as string;
+    await (globalThis as any).gapi.client.request({
+      path: `/drive/v3/files/${id}`,
+      method: 'PATCH',
+      body: { name: fileName }
+    });
+    return id;
+  }
+}
+
+export async function downloadFromDrive(fileId: string): Promise<string> {
+  await signIn();
+  const res = await (globalThis as any).gapi.client.request({
+    path: `/drive/v3/files/${fileId}`,
+    method: 'GET',
+    params: { alt: 'media' }
+  });
+  return res.body as string;
+}

--- a/test/googleDrive.test.js
+++ b/test/googleDrive.test.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+// DOM stubs similar to other tests
+const body = { children: [], appendChild(el){ this.children.push(el); el.parent=this; }, removeChild(el){ this.children = this.children.filter(c=>c!==el); } };
+function createElement(tag='div'){
+  const el = {
+    tagName: tag.toUpperCase(),
+    children: [],
+    style:{},
+    dataset:{},
+    classList:{ add(){}, remove(){}, contains(){ return false; } },
+    appendChild(child){ child.parent=this; this.children.push(child); },
+    append(child){ this.appendChild(child); },
+    querySelector(){ return null; },
+    setAttribute(){},
+    addEventListener(){},
+    textContent:''
+  };
+  if(tag==='input') el.type='';
+  if(tag==='img') el.src='';
+  if(tag==='a') el.href='';
+  return el;
+}
+const doc = { body, createElement, querySelector(){ return null; }, createRange(){ return { selectNodeContents(){} }; } };
+const win = { addEventListener(){}, location:{ href:'', replace(){} }, getSelection(){ return { removeAllRanges(){}, addRange(){} }; } };
+
+global.document = doc;
+global.window = win;
+
+global.localStorage = {
+  data:{},
+  getItem(k){ return this.data[k] || null; },
+  setItem(k,v){ this.data[k]=v; },
+  removeItem(k){ delete this.data[k]; }
+};
+
+let uploaded = false;
+let downloaded = false;
+require.cache[require.resolve('../cjs/googleDrive.js')] = { exports:{
+  uploadToDrive: async ()=>{ uploaded = true; return 'fileid'; },
+  downloadFromDrive: async ()=>{ downloaded = true; return '{"id":"1","parentId":"0","name":"t","borderColor":"#fff","created_dt":"2024-01-01T00:00:00.000Z","flexDirection":"column","host_url":null,"filename":null,"isFolded":false,"properties":{},"children":[]}'; }
+} };
+
+delete require.cache[require.resolve('../cjs/networks.js')];
+const nets = require('../cjs/networks.js');
+
+test('uploadData uses google drive when host_url is gdrive', async () => {
+  const tray = { host_url:'gdrive', filename:null, id:'1', name:'t', children:[] };
+  await nets.uploadData(tray);
+  assert.ok(uploaded);
+  assert.strictEqual(tray.filename, 'fileid');
+});
+
+test('downloadData uses google drive when host_url is gdrive', async () => {
+  const tray = { host_url:'gdrive', filename:'fileid', id:'1', name:'t' };
+  const t = await nets.downloadData(tray);
+  assert.ok(downloaded);
+  assert.strictEqual(typeof t, 'object');
+});


### PR DESCRIPTION
## Summary
- add a `googleDrive` helper with OAuth sign-in and file upload/download logic
- support `host_url` value `gdrive` in network functions
- test Google Drive integration

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684ca3430bc083249a71af0f3f7a6ee1