### PR TITLE
Implement automatic Google Drive prompt

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import {
   startAutoUpload,
   syncTray,
 } from "./networks";
+import { autoConnectDrive } from "./googleDrive";
 import { meltTray } from "./functions";
 import { Tray, TrayId } from "./tray";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
@@ -76,6 +77,8 @@ window.addEventListener("DOMContentLoaded", async () => {
       if (tray.autoUpload) startAutoUpload(tray);
     }
   }
+
+  await autoConnectDrive();
 
   // const { leftBar } = createHamburgerMenu();
   // console.log("leftBar:", leftBar); // Debug log

--- a/src/googleDrive.ts
+++ b/src/googleDrive.ts
@@ -109,3 +109,12 @@ export async function downloadFromDrive(fileId: string): Promise<string> {
   });
   return res.body as string;
 }
+
+export async function autoConnectDrive(): Promise<void> {
+  const clientId = localStorage.getItem('gdrive_client_id');
+  if (!clientId) return;
+  if (typeof (globalThis as any).confirm === 'function' && !(globalThis as any).confirm('Connect to Google Drive?')) {
+    return;
+  }
+  await connectGoogleDrive(clientId);
+}

--- a/test/autoConnectDrive.test.js
+++ b/test/autoConnectDrive.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+let confirmed = true;
+
+global.confirm = () => confirmed;
+
+global.document = {
+  body: { appendChild(el){ if(el.onload) el.onload(); } },
+  createElement(){ return { set src(v){}, onload:null, onerror:null }; }
+};
+
+global.gapi = { load: (_,cb)=>cb(), client:{ load: async()=>{}, request: async ()=>({result:{}, body:''}) } };
+
+global.google = { accounts:{ oauth2:{ initTokenClient: () => ({ callback:null, requestAccessToken(){ this.callback({}); } }) } } };
+
+global.localStorage = {
+  data:{},
+  getItem(k){ return this.data[k] || null; },
+  setItem(k,v){ this.data[k]=v; },
+  removeItem(k){ delete this.data[k]; }
+};
+
+const gd = require('../cjs/googleDrive.js');
+
+test('autoConnectDrive connects when confirmed', async () => {
+  global.localStorage.setItem('gdrive_client_id','cid');
+  confirmed = true;
+  await gd.autoConnectDrive();
+  assert.ok(gd.tokenClient);
+});
+
+test('autoConnectDrive skips when cancelled', async () => {
+  gd.tokenClient = null;
+  global.localStorage.setItem('gdrive_client_id','cid');
+  confirmed = false;
+  await gd.autoConnectDrive();
+  assert.strictEqual(gd.tokenClient, null);
+});
+
+test('autoConnectDrive does nothing without id', async () => {
+  gd.tokenClient = null;
+  global.localStorage.data = {};
+  confirmed = true;
+  await gd.autoConnectDrive();
+  assert.strictEqual(gd.tokenClient, null);
+});


### PR DESCRIPTION
## Summary
- auto-connect to Google Drive when a stored client ID exists
- call the new function after data loading
- test automatic Google Drive connection logic

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684d13cddfe48324b49ad6b2f38a9456