### PR TITLE
Fix tray focus outline and row layout overflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,12 @@
   box-shadow: 0 0 2px 2px rgba(0, 123, 255, 0.25); /* Custom focus indicator */
 }
 
+/* Tray focus outline */
+.tray:focus {
+  outline: 2px solid #3b99fc;
+  outline-offset: -2px; /* keep outline inside the element */
+}
+
 /* Created Time */
 .tray-created-time {
   font-size: 0.6em;
@@ -86,6 +92,7 @@
   flex: 1;
   min-width: 50%;
   width: 100px;
+  box-sizing: border-box;
   word-wrap: break-word;
   white-space: normal;
   font-weight: bold;
@@ -128,6 +135,7 @@
   /* padding-top: 10px; */
   padding-right: 0px;
   padding-bottom: 10px;
+  box-sizing: border-box;
   background-color: var(--tray-content-bg-color);
   display: flex;
   overflow-y: scroll;

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -418,7 +418,8 @@ export class Tray {
   updateChildrenAppearance() {
     this.children.forEach((child) => {
       if (this.flexDirection === "row") {
-        child.element.style.width = "50%"; // Or any appropriate width
+        child.element.style.boxSizing = "border-box";
+        child.element.style.width = "calc(50% - 3px)"; // account for borders
       } else {
         child.element.style.width = "100%";
       }


### PR DESCRIPTION
## Summary
- improve focus outline for trays
- prevent nested tray border overflow in row layout

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_685310f6001083248a9ea198430a16f5