### PR TITLE
Fix focus outline layering

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -77,8 +77,9 @@
 
 /* Tray focus outline */
 .tray:focus {
-  outline: 4px solid #000;
-  outline-offset: -2px; /* keep outline inside the element */
+  outline: none; /* avoid outline being hidden by child trays */
+  box-shadow: 0 0 0 4px #000; /* draw a visible focus ring above children */
+  position: relative;
   z-index: 11001; /* ensure outline appears above other elements */
 }
 


### PR DESCRIPTION
## Summary
- use `box-shadow` for tray focus ring to ensure it appears above children

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6853f4dd261c8324a2779f9e9afa313d