### PR TITLE
Fix focus ring layering without box-shadow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -77,9 +77,19 @@
 
 /* Tray focus outline */
 .tray:focus {
-  outline: 4px solid #000;
-  outline-offset: -2px; /* keep outline inside the element */
-  z-index: 11001; /* ensure outline appears above other elements */
+  outline: none; /* hide default outline */
+  position: relative;
+  z-index: 11001; /* place tray above other elements */
+}
+
+.tray:focus::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border: 4px solid #000; /* custom focus ring */
+  box-sizing: border-box;
+  z-index: 1; /* appear above tray children */
 }
 
 /* Created Time */


### PR DESCRIPTION
## Summary
- draw tray focus ring with a pseudo-element instead of `box-shadow`

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6853f4dd261c8324a2779f9e9afa313d