### PR TITLE
Improve hook view sorting

### DIFF
--- a/src/hamburger.ts
+++ b/src/hamburger.ts
@@ -837,20 +837,30 @@ export function showHookViewDialog(): void {
     hookContent.innerHTML = '<div style="text-align: center; color: #999; padding: 20px;">No tasks with hooks found. Use @hookname in tray names to organize by hooks.</div>';
   } else {
     hookContent.innerHTML = '';
-    
-    // Sort hooks alphabetically
-    const sortedHooks = Array.from(hookMap.keys()).sort();
-    
-    sortedHooks.forEach(hook => {
+
+    // Sort hooks by number of tasks and move hooks with only done tasks to the bottom
+    const hookEntries = Array.from(hookMap.entries());
+    hookEntries.sort((a, b) => {
+      const aDoneOnly = a[1].every(t => t.isDone);
+      const bDoneOnly = b[1].every(t => t.isDone);
+      if (aDoneOnly !== bDoneOnly) {
+        return aDoneOnly ? 1 : -1; // done-only hooks last
+      }
+      if (b[1].length !== a[1].length) {
+        return b[1].length - a[1].length; // sort by count desc
+      }
+      return a[0].localeCompare(b[0]);
+    });
+
+    hookEntries.forEach(([hook, taskList]) => {
       const hookSection = document.createElement("div");
       hookSection.style.cssText = "margin-bottom: 20px; border: 1px solid #ddd; border-radius: 6px; padding: 15px;";
-      
+
       const hookTitle = document.createElement("h4");
       hookTitle.textContent = `@${hook}`;
       hookTitle.style.cssText = "margin: 0 0 10px 0; color: #333; font-size: 1.1em; font-weight: bold;";
       hookSection.appendChild(hookTitle);
       
-      const taskList = hookMap.get(hook)!;
       taskList.forEach(tray => {
         const taskItem = document.createElement("div");
         const isDone = tray.isDone;

--- a/test/hookViewDialog.test.js
+++ b/test/hookViewDialog.test.js
@@ -79,3 +79,23 @@ test('dialog closes on outside click', () => {
   documentStub.onclick({ target: {} });
   assert.ok(!body.children.includes(dialog), 'dialog removed on outside click');
 });
+
+test('hooks sorted by frequency and done hooks last', () => {
+  rootTray.children = [
+    { id: '1', name: 't1', hooks: ['b'], isDone: false, borderColor: '#000', created_dt: new Date(), children: [] },
+    { id: '2', name: 't2', hooks: ['b'], isDone: false, borderColor: '#000', created_dt: new Date(), children: [] },
+    { id: '3', name: 't3', hooks: ['b'], isDone: true,  borderColor: '#000', created_dt: new Date(), children: [] },
+    { id: '4', name: 't4', hooks: ['a'], isDone: false, borderColor: '#000', created_dt: new Date(), children: [] },
+    { id: '5', name: 't5', hooks: ['c'], isDone: true,  borderColor: '#000', created_dt: new Date(), children: [] },
+    { id: '6', name: 't6', hooks: ['c'], isDone: true,  borderColor: '#000', created_dt: new Date(), children: [] }
+  ];
+
+  ham.showHookViewDialog();
+  const dialog = lastDialog();
+  const hookContent = dialog.querySelector('#hook-content');
+  const hookSections = hookContent.children.slice(2);
+  const order = hookSections.map(sec => sec.children[0].textContent);
+  assert.deepStrictEqual(order, ['@b', '@a', '@c']);
+  dialog.remove();
+  rootTray.children = [];
+});


### PR DESCRIPTION
## Summary
- sort hooks by how often they're used
- keep sections with only completed tasks at the bottom
- add unit test for new hook sorting logic

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_685f1c6329d083248b2df28b43b963ee