### PR TITLE
Add toggle for @@ display

### DIFF
--- a/test/trayLink.test.js
+++ b/test/trayLink.test.js
@@ -105,3 +105,16 @@ test('finishTitleEdit converts to image', () => {
   assert.ok(img);
   assert.strictEqual(img.src, 'https://foo.com/bar.jpg');
 });
+
+test('@@ marker hidden by default', () => {
+  const t = new Tray('0','6','Task @@done');
+  const title = t.element.querySelector('.tray-title');
+  assert.strictEqual(title.textContent, 'Task done');
+});
+
+test('toggleDoneMarker reveals @@', () => {
+  const t = new Tray('0','7','Task @@done');
+  const title = t.element.querySelector('.tray-title');
+  t.toggleDoneMarker(title);
+  assert.strictEqual(title.textContent, 'Task @@done');
+});


### PR DESCRIPTION
## Summary
- hide `@@` markers in tray titles by default
- allow clicking tray title to reveal/hide the marker
- reset marker visibility when editing ends
- test `@@` display toggle

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6860852d6400832481f63505066a6706