### PR TITLE
Improve markdown parsing

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -37,12 +37,26 @@ export function exportMarkdown(root: Tray) {
 export function addMarkdownToTray(markdown: string, parent: Tray) {
   const lines = markdown.split(/\r?\n/).filter((l) => l.trim() !== "");
   const lastAt: Tray[] = [];
+  let lastHeadingIndent = -1;
   for (const line of lines) {
-    const indentMatch = line.match(/^(\s*)/);
-    const indent = indentMatch ? Math.floor(indentMatch[1].length / 2) : 0;
-    const trimmed = line.trim().replace(/^[-*]\s*/, "");
+    const trimmedLine = line.trim();
+    if (!trimmedLine) continue;
+    const headingMatch = trimmedLine.match(/^(#+)\s*(.*)$/);
+    let indent: number;
+    let text: string;
+    if (headingMatch) {
+      indent = headingMatch[1].length - 1;
+      text = headingMatch[2];
+      lastHeadingIndent = indent;
+    } else {
+      const indentMatch = line.match(/^(\s*)/);
+      const bulletIndent = indentMatch ? Math.floor(indentMatch[1].length / 2) : 0;
+      text = trimmedLine.replace(/^[-*]\s*/, "");
+      indent = (lastHeadingIndent >= 0 ? lastHeadingIndent + 1 : 0) + bulletIndent;
+      if (lastHeadingIndent < 0) indent = bulletIndent;
+    }
     const p = indent === 0 ? parent : lastAt[indent - 1] || parent;
-    const child = new Tray(p.id, generateUUID(), trimmed);
+    const child = new Tray(p.id, generateUUID(), text);
     p.addChild(child);
     lastAt[indent] = child;
     lastAt.length = indent + 1;

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -104,3 +104,37 @@ test('pasteFromClipboardInto handles markdown indentation', async () => {
   assert.strictEqual(child.name, 'child');
   assert.strictEqual(child.children[0].name, 'grand');
 });
+
+delete require.cache[require.resolve('../cjs/markdown.js')];
+const md = require('../cjs/markdown.js');
+
+test('addMarkdownToTray handles heading hierarchy', () => {
+  const root = new Tray('0','r','root');
+  md.addMarkdownToTray('# parent\n## child\n### grand', root);
+  assert.strictEqual(root.children.length, 1);
+  const parent = root.children[0];
+  assert.strictEqual(parent.name, 'parent');
+  const child = parent.children[0];
+  assert.strictEqual(child.name, 'child');
+  assert.strictEqual(child.children[0].name, 'grand');
+});
+
+test('addMarkdownToTray handles heading with bullet list', () => {
+  const root = new Tray('0','r','root');
+  md.addMarkdownToTray('## parent\n- a\n  - b\n- c', root);
+  const parent = root.children[0];
+  assert.strictEqual(parent.name, 'parent');
+  assert.strictEqual(parent.children.length, 2);
+  assert.strictEqual(parent.children[0].name, 'c');
+  assert.strictEqual(parent.children[1].name, 'a');
+  assert.strictEqual(parent.children[1].children[0].name, 'b');
+});
+
+test('addMarkdownToTray ignores blank lines', () => {
+  const root = new Tray('0','r','root');
+  md.addMarkdownToTray('- a\n\n  - b\n\n- c', root);
+  assert.strictEqual(root.children.length, 2);
+  assert.strictEqual(root.children[0].name, 'c');
+  assert.strictEqual(root.children[1].name, 'a');
+  assert.strictEqual(root.children[1].children[0].name, 'b');
+});


### PR DESCRIPTION
## Summary
- support heading levels when pasting Markdown
- add unit tests for heading parsing and blank line handling

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_686997e5a36483248d627c48db1479fd